### PR TITLE
Updated results component to list sitename links

### DIFF
--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -21,6 +21,34 @@ class FederatedResult extends React.Component {
     }
   }
 
+  intersperse(arr, sep) {
+    if (arr.length === 0) {
+      return [];
+    }
+
+    return arr.slice(1).reduce(function(xs, x, i) {
+      return xs.concat([sep, x]);
+    }, [arr[0]]);
+  }
+
+  renderSitenameLinks(sitenames, urls) {
+    if (sitenames != null && urls != null) {
+      console.log(sitenames);
+      console.log(urls);
+
+      var sites = [];
+      for (var i = 0; i < sitenames.length; i++) {
+        sites.push(<a href={urls[i]}>{sitenames[i]}</a>);
+        if (i != (sitenames.length - 1)) {
+
+        }
+      }
+      return this.intersperse(sites, " | ");
+    }
+
+    return null;
+  }
+
   render() {
     const { doc, highlight } = this.props;
 
@@ -35,7 +63,7 @@ class FederatedResult extends React.Component {
           <span className="search-results__label">{doc.ss_federated_type}</span>
           <h3 className="search-results__heading"><a href={doc.ss_url}>{doc.ss_federated_title}</a></h3>
           <div className="search-results__meta">
-            <cite className="search-results__citation">{doc.ss_site_name}</cite>
+            <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_search_api_urls)}</cite>
             {this.dateFormat(doc.ds_federated_date)}
           </div>
           <p className="search-results__teaser" dangerouslySetInnerHTML={{__html: highlight.tm_rendered_item}} />


### PR DESCRIPTION
https://palantir.atlassian.net/browse/UMHS-21

Description:
- Display links to content on all sites 
- (the content will need to be indexed on the https://github.com/palantirnet/search_api_federated_solr/pull/41 branch)
- (Content that haven't been indexed on the above branch won't display any site_names)