### PR TITLE
Updated results to display old sitename field when needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palantirnet/federated-search-react",
   "description": "A ReactJS front end for faceted Solr search.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/palantirnet/federated-search-react",
   "license": "SEE LICENSE IN LICENSE",
   "private": true,

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -31,7 +31,7 @@ class FederatedResult extends React.Component {
     }, [arr[0]]);
   }
 
-  renderSitenameLinks(sitenames, urls) {
+  renderSitenameLinks(sitenames, urls, originalSitename) {
     if (sitenames != null && urls != null) {
       console.log(sitenames);
       console.log(urls);
@@ -44,6 +44,10 @@ class FederatedResult extends React.Component {
         }
       }
       return this.intersperse(sites, " | ");
+    }
+
+    if (originalSitename != null) {
+      return originalSitename;
     }
 
     return null;
@@ -63,7 +67,7 @@ class FederatedResult extends React.Component {
           <span className="search-results__label">{doc.ss_federated_type}</span>
           <h3 className="search-results__heading"><a href={doc.ss_url}>{doc.ss_federated_title}</a></h3>
           <div className="search-results__meta">
-            <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_search_api_urls)}</cite>
+            <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_search_api_urls, doc.ss_site_name)}</cite>
             {this.dateFormat(doc.ds_federated_date)}
           </div>
           <p className="search-results__teaser" dangerouslySetInnerHTML={{__html: highlight.tm_rendered_item}} />


### PR DESCRIPTION
Updated results to display old ss_sitename field when needed so that Nodes that haven't been re-indexed still work.

<img width="821" alt="screen shot 2018-08-30 at 9 32 58 am" src="https://user-images.githubusercontent.com/6313372/44858474-bbe00680-ac37-11e8-84f9-f5a162b378c8.png">