### PR TITLE
HOTFIX-umus-21-update-urls-field (D8)

### DIFF
--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -67,7 +67,7 @@ class FederatedResult extends React.Component {
           <span className="search-results__label">{doc.ss_federated_type}</span>
           <h3 className="search-results__heading"><a href={doc.ss_url}>{doc.ss_federated_title}</a></h3>
           <div className="search-results__meta">
-            <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_search_api_urls, doc.ss_site_name)}</cite>
+            <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_urls, doc.ss_site_name)}</cite>
             {this.dateFormat(doc.ds_federated_date)}
           </div>
           <p className="search-results__teaser" dangerouslySetInnerHTML={{__html: highlight.tm_rendered_item}} />


### PR DESCRIPTION
### Description

Changes the `sm_search_api_urls` field to `sm_urls` in the display results. This change was also made in the indexing of the d7 and d8 versions of search api frederated solr.

### To Test (these are instructions for all the moving parts here)

- go to umus repo UMUS
- Checkout `unified-search` on web/uofmhealth
- Checkout `HOTFIX-umus-21-update-federated-solr-module` on web/umichphysd8
- Checkout `HOTFIX-umus-21-search-api-urls-to-urls` on src/search_api_federated_solr-7.x
- Checkout `HOTFIX-umus-21-update-urls-sitename-index` on src/search_api_federated_solr`

OUTSIDE OF UMUS
- go to the `federated-search-react` repo
- Checkout `HOTFIX-umus-21-update-urls-field`
- run `yarn build` and copy the compiled js into the D8 & D& search_api_federated_solr modules in umus.

- go to https://labblog.uofmhealth.local/admin/config/search/search-api and enable the server and index.
- go to https://labblog.uofmhealth.local/admin/config/search/search-api/index/federated_search_index/fields and add the 
- run `drush @uofmhealth.local en search_api_federated_solr uofmhealth_federated_search_configuration -y`

- Alter a piece of content on uofmhealth.local and see that it's index contains `sm_urls` and `sm_site_name` view the content on the search results page and confirm that it displays the stitename below the title.
- Do the same ^ for  labblog.uofmhealth.local


### Merge order:

1. `federated-search-react` and create new release to be used in both search_api_federated_solr D7 & D8.
2. 