### PR TITLE
Results bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,7 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
-  "dependencies": {}
+  "dependencies": {
+    "intl": "^1.2.5"
+  }
 }

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import React from "react";
+import 'intl';
+import 'intl/locale-data/jsonp/en';
 
 // Custom class for the result component
 class FederatedResult extends React.Component {

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -65,7 +65,7 @@ class FederatedResult extends React.Component {
         }
         <div className="search-results__container--right">
           <span className="search-results__label">{doc.ss_federated_type}</span>
-          <h3 className="search-results__heading"><a href={doc.ss_url}>{doc.ss_federated_title}</a></h3>
+          <h3 className="search-results__heading"><a href={doc.ss_url} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
           <div className="search-results__meta">
             <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_urls, doc.ss_site_name)}</cite>
             {this.dateFormat(doc.ds_federated_date)}

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -41,7 +41,7 @@ class FederatedResult extends React.Component {
       var sites = [];
       for (var i = 0; i < sitenames.length; i++) {
         sites.push(<a href={urls[i]}>{sitenames[i]}</a>);
-        if (i != (sitenames.length - 1)) {
+        if (i !== (sitenames.length - 1)) {
 
         }
       }

--- a/src/components/sort-menu/_search-scope.scss
+++ b/src/components/sort-menu/_search-scope.scss
@@ -50,7 +50,7 @@
   appearance: none;
   margin-bottom: rhythm(.75);
   width: 100% !important;
-  background-image: url("imgs/chevron-small-down.svg");
+  background-image: url("data:image/svg+xml;charset=UTF-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><path d='M8.3 2.8c.3-.3.7-.3 1 0 .3.3.3.7 0 1L5.4 7.6c-.3.3-.7.3-1 0L.5 3.7c-.3-.3-.3-.7 0-1 .3-.3.7-.3 1 0l3.4 3.1 3.4-3z'/></svg>");
   background-repeat: no-repeat;
   background-position: 90% 50%;
   background-size: .6em .6em;

--- a/src/components/sort-menu/_search-scope.scss
+++ b/src/components/sort-menu/_search-scope.scss
@@ -50,7 +50,7 @@
   appearance: none;
   margin-bottom: rhythm(.75);
   width: 100% !important;
-  background-image: url("data:image/svg+xml;charset=UTF-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><path d='M8.3 2.8c.3-.3.7-.3 1 0 .3.3.3.7 0 1L5.4 7.6c-.3.3-.7.3-1 0L.5 3.7c-.3-.3-.3-.7 0-1 .3-.3.7-.3 1 0l3.4 3.1 3.4-3z'/></svg>");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M8.3 2.8c.3-.3.7-.3 1 0 .3.3.3.7 0 1L5.4 7.6c-.3.3-.7.3-1 0L.5 3.7c-.3-.3-.3-.7 0-1 .3-.3.7-.3 1 0l3.4 3.1 3.4-3z'%3E%3C/path%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: 90% 50%;
   background-size: .6em .6em;

--- a/src/imgs/chevron-small-down.svg
+++ b/src/imgs/chevron-small-down.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Chevron_small_down" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" viewBox="0 0 10 10" style="enable-background:new 0 0 10 10;" xml:space="preserve">
-<path d="M8.3,2.8c0.3-0.3,0.7-0.3,1,0c0.3,0.3,0.3,0.7,0,1L5.4,7.6c-0.3,0.3-0.7,0.3-1,0L0.5,3.7c-0.3-0.3-0.3-0.7,0-1
-	c0.3-0.3,0.7-0.3,1,0l3.4,3.1L8.3,2.8z"/>
-</svg>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1530,7 +1530,7 @@ aside {
   appearance: none;
   margin-bottom: 1.1em;
   width: 100% !important;
-  background-image: url("imgs/chevron-small-down.svg");
+  background-image: url("data:image/svg+xml;charset=UTF-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><path d='M8.3 2.8c.3-.3.7-.3 1 0 .3.3.3.7 0 1L5.4 7.6c-.3.3-.7.3-1 0L.5 3.7c-.3-.3-.3-.7 0-1 .3-.3.7-.3 1 0l3.4 3.1 3.4-3z'/></svg>");
   background-repeat: no-repeat;
   background-position: 90% 50%;
   background-size: .6em .6em;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1530,7 +1530,7 @@ aside {
   appearance: none;
   margin-bottom: 1.1em;
   width: 100% !important;
-  background-image: url("data:image/svg+xml;charset=UTF-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><path d='M8.3 2.8c.3-.3.7-.3 1 0 .3.3.3.7 0 1L5.4 7.6c-.3.3-.7.3-1 0L.5 3.7c-.3-.3-.3-.7 0-1 .3-.3.7-.3 1 0l3.4 3.1 3.4-3z'/></svg>");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M8.3 2.8c.3-.3.7-.3 1 0 .3.3.3.7 0 1L5.4 7.6c-.3.3-.7.3-1 0L.5 3.7c-.3-.3-.3-.7 0-1 .3-.3.7-.3 1 0l3.4 3.1 3.4-3z'%3E%3C/path%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: 90% 50%;
   background-size: .6em .6em;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4012,6 +4012,10 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+
 invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
- Fixes decoded apostrophe in carrots entry <img width="699" alt="screenshot_9_28_18__12_22_pm" src="https://user-images.githubusercontent.com/238201/46223474-22307580-c319-11e8-982c-4a0980f91e09.png">
- Fixes missing `chevron-small-down` in https://github.com/palantirnet/search_api_federated_solr/pull/44/files
- Fixes site not loading in Safari on iOS9 due to missing `intl` library
- Fixes warning from https://github.com/palantirnet/federated-search-react/pull/16/files#diff-44b6781b2e9835557c3df782d1250b97R42