### PR TITLE
HOTFIX-UMUS-21-fix-sitename-filter

### DIFF
--- a/src/components/current-query/index.js
+++ b/src/components/current-query/index.js
@@ -64,7 +64,7 @@ class ListFacetType extends React.Component {
     // @todo handle parsing of terms and dates
     // @todo store this in app config?
     const filterFieldsWithQsState = [
-      "ss_site_name",
+      "sm_site_name",
       "ss_federated_type"
     ];
 

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -133,7 +133,7 @@ FederatedSolrFacetedSearch.defaultProps = {
   sortFields: [],
   truncateFacetListsAt: -1,
   showCsvExport: false,
-  sidebarFilters: ['ss_site_name', 'ss_federated_type', 'ds_federated_date', 'sm_federated_terms'],
+  sidebarFilters: ['sm_site_name', 'ss_federated_type', 'ds_federated_date', 'sm_federated_terms'],
   options: {}
 };
 

--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -25,7 +25,7 @@ class FederatedListFacet extends React.Component {
     // @todo handle parsing of terms and dates
     // @todo store this in app config?
     const filterFieldsWithQsState = [
-      "ss_site_name",
+      "sm_site_name",
       "ss_federated_type"
     ];
 

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -36,7 +36,7 @@ class FederatedResult extends React.Component {
 
       var sites = [];
       for (var i = 0; i < sitenames.length; i++) {
-        sites.push(<a href={urls[i]}>{sitenames[i]}</a>);
+        sites.push(<a href={urls[i]} key={i}>{sitenames[i]}</a>);
         if (i != (sitenames.length - 1)) {
 
         }

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -33,8 +33,6 @@ class FederatedResult extends React.Component {
 
   renderSitenameLinks(sitenames, urls, originalSitename) {
     if (sitenames != null && urls != null) {
-      console.log(sitenames);
-      console.log(urls);
 
       var sites = [];
       for (var i = 0; i < sitenames.length; i++) {

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ const searchFromQuerystring = (solrClient, options = {}) => {
       // @todo handle parsing of terms and dates
       // @todo store this in app config?
       const filterFieldsWithQsState = [
-        "ss_site_name",
+        "sm_site_name",
         "ss_federated_type"
       ];
 
@@ -86,7 +86,7 @@ const init = (settings) => {
     // The search fields and filterable facets.
     searchFields: [
       {label: "Enter Search Term:", field: "tm_rendered_item", type: "text"},
-      {label: "Site Name", field: "ss_site_name", type: "list-facet", collapse: true},
+      {label: "Site Name", field: "sm_site_name", type: "list-facet", collapse: true},
       {label: "Type", field: "ss_federated_type", type: "list-facet", collapse: true},
       {label: "Date", field: "ds_federated_date", type: "range-facet", collapse: true},
       {label: "Federated Terms", field: "sm_federated_terms", type: "list-facet", hierarchy: true},


### PR DESCRIPTION
[See Comment on UMHS-21](https://palantir.atlassian.net/browse/UMHS-21?focusedCommentId=54225&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-54225)

In altering the site_name field to be indexed as multi-valued, the site name filter no longer worked.

Fixed site name filter to work with multi-field site-name field.

### Description

- Find and replace all instances of `ss_site_name` with `sm_site_name` and filters began working again!

### Todo

- Verify the functionality is truely working properly with the "Find and replace" solution above.
- My concern is that the `sm_site_name` is now and array instead of a string, so I'd imagine there should be some logic that need be updated.