### PR TITLE
Paging bug

### DIFF
--- a/src/components/results/count-label.js
+++ b/src/components/results/count-label.js
@@ -7,7 +7,7 @@ function searchResultsStat(currentPage, numFound, rows, pageAmt, noResultsText) 
       <p id="stat" tabIndex="-1" className="search-results-stat">Showing page <strong>{currentPage+1}</strong> of <strong>{pageAmt}</strong> (<strong>{numFound}</strong> results). </p>
     )
   }
-  else if (numFound < rows && numFound > 1) { // Single page
+  else if (numFound <= rows && numFound > 1) { // Single page
     return (
       <p id="stat" tabIndex="-1" className="search-results-stat">Showing <strong>{numFound}</strong> results.</p>
     )

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,8 @@ const init = (settings) => {
           {...handlers}
           customComponents={FederatedSolrComponentPack}
           bootstrapCss={false}
-          onSelectDoc={(doc) => console.log(doc)}
+          //onSelectDoc={(doc) => console.log(doc)}
+          onSelectDoc={()=>{}}
           truncateFacetListsAt={-1}
           options={options}
         />,


### PR DESCRIPTION
While testing I discovered that a search resulting in exactly one page of results will barf due to a missing condition. Resolved this, and hid some long-standing debugging code.