### PR TITLE
UMUS-21 Update link behavior to use urls field

### DIFF
--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -35,4 +35,6 @@ module.exports = {
   paginationButtons: 5,
   // OPTIONAL: The title of the search results page (null to hide).
   pageTitle: null,
+  // OPTIONAL: The hostname to emulate when testing.
+  hostname: "example.local",
 };

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -109,6 +109,7 @@ class FederatedSolrFacetedSearch extends React.Component {
                                      rows={rows}
                                      start={start}
                                      highlight={results.highlighting[doc.id]}
+                                     hostname={this.props.options.hostname}
                     />
                 ))}
                 {preloadListItem}

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -23,6 +23,21 @@ class FederatedResult extends React.Component {
     }
   }
 
+  getCanonicalLink(urls) {
+    const { hostname } = this.props;
+
+    // If one of our links matches the current site, use it.
+    for (let i = 0; i < urls.length; i++) {
+      const url = new URL(urls[i]);
+      if (url.hostname === hostname) {
+        return urls[i];
+      }
+    }
+
+    // Otherwise, use the first in the list, which is the canonical (or only).
+    return urls[0];
+  }
+
   intersperse(arr, sep) {
     if (arr.length === 0) {
       return [];
@@ -65,7 +80,7 @@ class FederatedResult extends React.Component {
         }
         <div className="search-results__container--right">
           <span className="search-results__label">{doc.ss_federated_type}</span>
-          <h3 className="search-results__heading"><a href={doc.ss_url} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
+          <h3 className="search-results__heading"><a href={this.getCanonicalLink(doc.sm_urls)} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
           <div className="search-results__meta">
             <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_urls, doc.ss_site_name)}</cite>
             {this.dateFormat(doc.ds_federated_date)}
@@ -80,7 +95,8 @@ class FederatedResult extends React.Component {
 FederatedResult.propTypes = {
 	doc: PropTypes.object,
 	fields: PropTypes.array,
-	onSelect: PropTypes.func.isRequired
+	onSelect: PropTypes.func.isRequired,
+    hostname: PropTypes.string,
 };
 
 export default FederatedResult;

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,9 @@ const init = (settings) => {
       usePhraseHighlighter: true // highlight phrase queries
     },
     pageStrategy: "paginate",
-    rows: 20
+    rows: 20,
+    // Hostname overridable in ./.env.local.js for testing purposes.
+    hostname: window.location.hostname,
   };
 
   const options = Object.assign(defaults, settings);


### PR DESCRIPTION
To test:
- Create or edit `.env.local.js` and set the following 
```
  url: "https://ss826806-us-east-1-aws.measuredsearch.com:443/solr/master/select",
  userpass: btoa("palantir:palantirqauser"),
```
- `yarn start`
- Search for "breastfeeding"
- Observe "Breastfeeding Resources" links to the same url as the first item in the list of sites (CS Mott...)
- Edit `.env.local.js` and set: `hostname: "umwomenshealth.org",`
- Observe the site reloads and "Breastfeeding Resources now links to Von Voigtlander Women's Hospital.