### PR TITLE
UMHS-24 render error

### DIFF
--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -135,7 +135,7 @@ class FederatedListFacet extends React.Component {
       // Remove duplicate types
       // So facet values of "Condition>Bones", "Condition>Bone growth" should only
       // Add "Condition" type once so we only render 1 Condition accordion group.
-      const uniqueTypes = types.filter((value, index, self) => self.indexOf(value) === index);
+      const uniqueTypes = types.filter((value, index, self) => self.indexOf(value) === index).filter(String);
 
       // Define array of accordion Lis which we'll populate with react fragments.
       let listFacetHierarchyLis = [];

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -43,7 +43,8 @@ class FederatedResult extends React.Component {
       return url;
     }
 
-    // If no valid urls are passed, return nothing.
+    // If no valid urls are passed, return nothing. This will result in an
+    // unlinked title, but at least it won't crash.
     return [];
   }
 

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -23,19 +23,28 @@ class FederatedResult extends React.Component {
     }
   }
 
-  getCanonicalLink(urls) {
+  // Pass both the mutivalue and the single value url as a backup.
+  getCanonicalLink(urls, url) {
     const { hostname } = this.props;
 
-    // If one of our links matches the current site, use it.
-    for (let i = 0; i < urls.length; i++) {
-      const url = new URL(urls[i]);
-      if (url.hostname === hostname) {
-        return urls[i];
+    if (urls != null) {
+      // If one of our links matches the current site, use it.
+      for (let i = 0; i < urls.length; i++) {
+        const url = new URL(urls[i]);
+        if (url.hostname === hostname) {
+          return urls[i];
+        }
       }
+      // Otherwise, use the first in the list, which is the canonical (or only).
+      return urls[0];
     }
 
-    // Otherwise, use the first in the list, which is the canonical (or only).
-    return urls[0];
+    if (url != null) {
+      return url;
+    }
+
+    // If no valid urls are passed, return nothing.
+    return [];
   }
 
   intersperse(arr, sep) {
@@ -80,7 +89,7 @@ class FederatedResult extends React.Component {
         }
         <div className="search-results__container--right">
           <span className="search-results__label">{doc.ss_federated_type}</span>
-          <h3 className="search-results__heading"><a href={this.getCanonicalLink(doc.sm_urls)} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
+          <h3 className="search-results__heading"><a href={this.getCanonicalLink(doc.sm_urls, doc.ss_url)} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
           <div className="search-results__meta">
             <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_urls, doc.ss_site_name)}</cite>
             {this.dateFormat(doc.ds_federated_date)}


### PR DESCRIPTION
Resolves two issues:
- application crashes if no `urls` field exists (see report from [UMHS-24](https://palantir.atlassian.net/browse/UMHS-24))
- empty strings in `sm_federated_terms` field can cause funky empty dropdown. 

<img width="333" alt="solr_admin" src="https://user-images.githubusercontent.com/238201/47382058-04abbd00-d6c7-11e8-8506-c813e43fc76b.png">
<img width="354" alt="search___federated_search_demo" src="https://user-images.githubusercontent.com/238201/47382075-11301580-d6c7-11e8-8208-e87bf3a76cc1.png">
