### PR TITLE
Pl 10 add config option to allow for empty search

### DIFF
--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -28,7 +28,7 @@ module.exports = {
   // OPTIONAL: The text to display when a search returns no results.
   noResults: "Sorry, your search yielded no results.",
   // OPTIONAL: Whether or not to display all results on empty search.
-  showEmptySearchResults: true,
+  showEmptySearchResults: false,
   // OPTIONAL: The text to display when the app loads with no search term.
   searchPrompt: "Please enter a search term.",
   // OPTIONAL: The number of search results to show per page.

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -27,6 +27,8 @@ module.exports = {
   siteSearch: null,
   // OPTIONAL: The text to display when a search returns no results.
   noResults: "Sorry, your search yielded no results.",
+  // OPTIONAL: Whether or not to display all results on empty search.
+  showEmptySearchResults: true,
   // OPTIONAL: The text to display when the app loads with no search term.
   searchPrompt: "Please enter a search term.",
   // OPTIONAL: The number of search results to show per page.

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -91,8 +91,8 @@ class FederatedSolrFacetedSearch extends React.Component {
               <CurrentQueryComponent {...this.props} onChange={onSearchFieldChange} />
               <SortComponent bootstrapCss={bootstrapCss} onChange={onSortFieldChange} sortFields={sortFields} />
             </div>
-            <p className={searchFields.find((sf) => sf.field === "tm_rendered_item").value ? 'solr-search-results-container__prompt element-invisible' : 'solr-search-results-container__prompt'}>{this.props.options.searchPrompt || 'Please enter a search term.'}</p>
-            <div className={searchFields.find((sf) => sf.field === "tm_rendered_item").value ? 'solr-search-results-container__wrapper' : 'solr-search-results-container__wrapper element-invisible'}>
+            <p className={(searchFields.find((sf) => sf.field === "tm_rendered_item").value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__prompt element-invisible' : 'solr-search-results-container__prompt'}>{this.props.options.searchPrompt || 'Please enter a search term.'}</p>
+            <div className={(searchFields.find((sf) => sf.field === "tm_rendered_item").value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__wrapper' : 'solr-search-results-container__wrapper element-invisible'}>
               <ResultContainerComponent bootstrapCss={bootstrapCss}>
               <ResultHeaderComponent bootstrapCss={bootstrapCss}>
                 <ResultCount bootstrapCss={bootstrapCss} numFound={results.numFound} start={start} rows={rows} onChange={onPageChange} noResultsText={this.props.options.noResults || null} />


### PR DESCRIPTION
[PL-10](https://palantir.atlassian.net/browse/PL-10)

## Ticket Description
Add "Show results for empty search" (`empty-search-results` or something) option to federated-search-react and create the corresponding config option search_api_federated_solr D8 and D7 branches. This should be a boolean that defaults to false.
Reconfigure react components to behave based on that config.

## PR Description
This PR adds logic to handle the `showEmptySearchResults` config setting in the react app. Only hiding empty search results when `showEmptySearchResults` is false. It also sets a default value of false in .env.local.js.example.

## To Test
1. Run `yarn install` from the ederated-search-react repo root.
1. Create a `src/.env.local.js` configuration file.
1. Make sure you're using the [PL-10-Add-config-option-to-allow-for-empty-search](https://github.com/palantirnet/solr-faceted-search-react/pull/6) branch in the solr-faceted-search-react node module.
1. set `showEmptySearchResults: true` in .env.local.js
1. Configure the search app to use a solr server ( I used http://federated-search-demo.local:8983/solr/drupal8/select)
1.  run `yarn start`
1. View that search shows results with an empty search.
