### PR TITLE
Root 198: add search-as-you-type autocomplete functionality option to text search

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,11 @@
       "error", {
         "devDependencies": true
       }
+    ],
+    "react/jsx-filename-extension": [
+      1, {
+        "extensions": [".js", ".jsx"],
+      }
     ]
   },
   "env": {

--- a/README.md
+++ b/README.md
@@ -84,11 +84,12 @@ TODO
 
 ### Requiring this project as a dependency
 
-Because this repo is currently private, it can't be included via public registries. I can still be included via `npm`/`yarn` as follows, assuming you have read access to this repo and GitHub SSH keys set up locally:
+Deploying this package produces production-ready JS and CSS files that can be referenced in a project as external dependencies. For example:
 
-`yarn add @palantirnet/federated-search-react:git+ssh://git@github.com:palantirnet/federated-search-react.git#v1.0.1`
+- CSS: `https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/css/main.cf6a58ce.css`
+- JS: `https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/js/main.d41fc3fe.js`
 
-To update the package, increment the version number accordingly and run `yarn install`.
+To update the package, increment the version number AND hash for each file based on the current release.
 
 ## Additional documentation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palantirnet/federated-search-react",
   "description": "A ReactJS front end for faceted Solr search.",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "homepage": "https://github.com/palantirnet/federated-search-react",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-with-direction": "1.3.0",
     "replace-x": "1.5.0",
     "singularitygs": "^1.7.0",
-    "solr-faceted-search-react": "git+ssh://git@github.com:palantirnet/solr-faceted-search-react#root-138-autocomplete"
+    "solr-faceted-search-react": "https://github.com/palantirnet/solr-faceted-search-react"
   },
   "scripts": {
     "theme-styles": "node-sass-chokidar ./theme/search_theme_override.scss ./public/css/search_theme_override.css --watch",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-with-direction": "1.3.0",
     "replace-x": "1.5.0",
     "singularitygs": "^1.7.0",
-    "solr-faceted-search-react": "https://github.com/palantirnet/solr-faceted-search-react"
+    "solr-faceted-search-react": "git+ssh://git@github.com:palantirnet/solr-faceted-search-react#root-138-autocomplete"
   },
   "scripts": {
     "theme-styles": "node-sass-chokidar ./theme/search_theme_override.scss ./public/css/search_theme_override.css --watch",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "he": "1.2.0",
     "intl": "^1.2.5",
     "react-autosuggest": "9.4.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palantirnet/federated-search-react",
   "description": "A ReactJS front end for faceted Solr search.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "homepage": "https://github.com/palantirnet/federated-search-react",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palantirnet/federated-search-react",
   "description": "A ReactJS front end for faceted Solr search.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "homepage": "https://github.com/palantirnet/federated-search-react",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palantirnet/federated-search-react",
   "description": "A ReactJS front end for faceted Solr search.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "homepage": "https://github.com/palantirnet/federated-search-react",
   "license": "SEE LICENSE IN LICENSE",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "he": "1.2.0",
     "intl": "^1.2.5",
+    "react-aria-live": "2.0.2",
     "react-autosuggest": "9.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palantirnet/federated-search-react",
   "description": "A ReactJS front end for faceted Solr search.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "homepage": "https://github.com/palantirnet/federated-search-react",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palantirnet/federated-search-react",
   "description": "A ReactJS front end for faceted Solr search.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/palantirnet/federated-search-react",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "intl": "^1.2.5"
+    "intl": "^1.2.5",
+    "react-autosuggest": "9.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@palantirnet/federated-search-react",
   "description": "A ReactJS front end for faceted Solr search.",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "homepage": "https://github.com/palantirnet/federated-search-react",
   "license": "MIT",
   "private": false,

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -12,6 +12,8 @@
  * - The optional settings illustrate the default values, which are hard
  *   coded into the app.  You only need to populate them in this file to change
  *   them from what you see below.
+ *
+ * If you set autocomplete to a configuration object, there are some required items in that object noted below.
  */
 
 module.exports = {
@@ -41,14 +43,18 @@ module.exports = {
   hostname: "example.local",
   // OPTIONAL: Provides config for adding autocomplete functionality to text search
   // autocomplete : {
-  //   url: <your-endpoint-for-autocomplete-results> // required @todo document accepted types
-  //   queryField: 'tem_suggestion_title' // required
-  //   suggestionRows: 5, // required - no current default set
-  //   numChars: 2, // optional: defaults to 2, number of characters *after* which autocomplete results should appear
-  //   mode: 'result' || 'term', // required: describes search-as-you-type results or search term suggestions
-  //   [mode]: { // define mode-specific config
-  //     titleText: 'What are you interested in?' // optional, default set
-  //     directionsText: true, // optional, defaults to false
-  //   }
-  // }
+  //   url: <your-endpoint-for-autocomplete-results>, // required @todo document accepted types
+  //   queryField: 'tem_suggestion_title', // REQUIRED
+  //   suggestionRows: 5, // REQUIRED: no current default set
+  //   numChars: 2, // OPTIONAL: defaults to 2, number of characters *after* which autocomplete results should appear
+  //   mode: 'result', // REQUIRED: show search-as-you-type results ('result', default) or search term ('term') suggestions
+  //   result: { // OPTIONAL: define result based autocomplete-specific config
+  //     titleText: 'What are you interested in?', // OPTIONAL: default set
+  //     showDirectionsText: true, // OPTIONAL: defaults to true
+  //   },
+  //   term: { // OPTIONAL: define term based autocomplete-specific config
+  //     titleText: 'What would you like to search for?', // OPTIONAL: default set
+  //     showDirectionsText: true, // OPTIONAL: defaults to false
+  //   },
+  // },
 };

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -39,4 +39,10 @@ module.exports = {
   pageTitle: null,
   // OPTIONAL: The hostname to emulate when testing.
   hostname: "example.local",
+  // OPTIONAL: Provides config for adding autocomplete functionality to text search
+  // autocomplete : {
+  //  mode: 'result' || 'term', // required: search-as-you-type results or search term suggestions
+  //  url: <your-endpoint-for-autocomplete-results> // required @todo document accepted types
+  //  queryField: 'tem_suggestion_title' // required
+  // }
 };

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -44,6 +44,7 @@ module.exports = {
   //   url: <your-endpoint-for-autocomplete-results> // required @todo document accepted types
   //   queryField: 'tem_suggestion_title' // required
   //   suggestionRows: 5, // required - no current default set
+  //   numChars: 2, // optional: defaults to 2, number of characters *after* which autocomplete results should appear
   //   mode: 'result' || 'term', // required: describes search-as-you-type results or search term suggestions
   //   [mode]: { // define mode-specific config
   //     titleText: 'What are you interested in?' // optional, default set

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -49,7 +49,7 @@ module.exports = {
   // OPTIONAL: Provides config for adding autocomplete functionality to text search, defaults to false
   // autocomplete : {
   //   url: <your-endpoint-for-autocomplete-results>, // required @todo document accepted types
-  //   appendWildcard: true, // OPTIONAL: defaults to false, whether or not to append wildcard to query term
+  //   appendWildcard: false, // OPTIONAL: defaults to false, whether or not to append wildcard to query term
   //   suggestionRows: 5, // OPTIONAL: defaults to 5
   //   numChars: 2, // OPTIONAL: defaults to 2, number of characters *after* which autocomplete results should appear
   //   mode: 'result', // REQUIRED: show search-as-you-type results ('result', default) or search term ('term') suggestions
@@ -59,7 +59,7 @@ module.exports = {
   //   },
   //   term: { // OPTIONAL: define term based autocomplete-specific config
   //     titleText: 'What would you like to search for?', // OPTIONAL: default set
-  //     showDirectionsText: false, // OPTIONAL: defaults to true
+  //     showDirectionsText: true, // OPTIONAL: defaults to true
   //   },
   // },
 };

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -41,8 +41,13 @@ module.exports = {
   hostname: "example.local",
   // OPTIONAL: Provides config for adding autocomplete functionality to text search
   // autocomplete : {
-  //  mode: 'result' || 'term', // required: search-as-you-type results or search term suggestions
-  //  url: <your-endpoint-for-autocomplete-results> // required @todo document accepted types
-  //  queryField: 'tem_suggestion_title' // required
+  //   url: <your-endpoint-for-autocomplete-results> // required @todo document accepted types
+  //   queryField: 'tem_suggestion_title' // required
+  //   suggestionRows: 5, // required - no current default set
+  //   mode: 'result' || 'term', // required: describes search-as-you-type results or search term suggestions
+  //   [mode]: { // define mode-specific config
+  //     titleText: 'What are you interested in?' // optional, default set
+  //     directionsText: true, // optional, defaults to false
+  //   }
   // }
 };

--- a/src/components/_aside.scss
+++ b/src/components/_aside.scss
@@ -2,7 +2,7 @@
  * aside.scss
  * Define aside styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 aside {

--- a/src/components/_aside.scss
+++ b/src/components/_aside.scss
@@ -2,7 +2,7 @@
  * aside.scss
  * Define aside styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 aside {

--- a/src/components/_search-filters.scss
+++ b/src/components/_search-filters.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 .search-filters__trigger,

--- a/src/components/_search-filters.scss
+++ b/src/components/_search-filters.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-filters__trigger,

--- a/src/components/current-query/_applied-filters.scss
+++ b/src/components/current-query/_applied-filters.scss
@@ -13,6 +13,7 @@
 .applied-filters__filter {
   @include adjust-font-size-to($label, .8);
   padding-bottom: rhythm(.2);
+  border: 0;
   border-bottom: solid 2px $c-secondary;
   margin-right: rhythm(.5);
   margin-bottom: rhythm(.5);

--- a/src/components/current-query/_applied-filters.scss
+++ b/src/components/current-query/_applied-filters.scss
@@ -2,7 +2,7 @@
  * applied-filters.scss
  * Define applied filters styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 .applied-filters {

--- a/src/components/current-query/_applied-filters.scss
+++ b/src/components/current-query/_applied-filters.scss
@@ -2,7 +2,7 @@
  * applied-filters.scss
  * Define applied filters styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .applied-filters {

--- a/src/components/current-query/index.js
+++ b/src/components/current-query/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import moment from 'moment';
+import { LiveMessenger } from 'react-aria-live';
+
 
 // Create dumb component which can be configured by props.
 const FacetType = props => (
@@ -16,6 +18,7 @@ const FacetType = props => (
 // Configure and render the FacetType component to render as list facet type.
 class ListFacetType extends React.Component {
   removeListFacetValue(field, values, value) {
+    this.props.announcePolite(`Removed ${field.value} filter.`);
     const foundIdx = values.indexOf(value);
     // Get existing querystring params.
     const parsed = queryString.parse(window.location.search);
@@ -69,6 +72,7 @@ class ListFacetType extends React.Component {
 // Configure and render the FacetType component to render as range facet type.
 class RangeFacetType extends React.Component {
   removeRangeFacetValue(field) {
+    this.props.announcePolite(`Removed ${field.value} filter.`);
     this.props.onChange(field, []);
   }
 
@@ -101,6 +105,7 @@ class RangeFacetType extends React.Component {
 // Configure and render the FacetType component to render as text facet type.
 class TextFacetType extends React.Component {
   removeTextValue(field) {
+    this.props.announcePolite(`Removed search term ${field.value}.`);
     this.props.onChange(field, '');
     // Get current querystring params.
     const parsed = queryString.parse(window.location.search);
@@ -149,23 +154,34 @@ class FederatedCurrentQuery extends React.Component {
     };
 
     return (
-      <React.Fragment>
-        {fields.length > 0 && // Only render this if there are filters applied.
-          <div className="applied-filters">
-            <h2 className="element-invisible">
-              Currently Applied Search Filters.
-            </h2>
-            <p className="element-invisible">
-              Click a filter to remove it from your search query.
-            </p>
-            {fields.map((searchField, i) => {
-              // Determine which child component to render.
-              const MyFacetType = facetTypes[searchField.type];
-              return <MyFacetType key={i} searchField={searchField} {...this.props} />;
-            })}
-          </div>
-        }
-      </React.Fragment>
+      <LiveMessenger>
+        {({ announcePolite }) => (
+          <React.Fragment>
+            {fields.length > 0 && // Only render this if there are filters applied.
+              <div className="applied-filters">
+                <h2 className="element-invisible">
+                  Currently Applied Search Filters.
+                </h2>
+                <p className="element-invisible">
+                  Click a filter to remove it from your search query.
+                </p>
+                {fields.map((searchField, i) => {
+                  // Determine which child component to render.
+                  const MyFacetType = facetTypes[searchField.type];
+                  return (
+                    <MyFacetType
+                      {...this.props}
+                      key={i}
+                      searchField={searchField}
+                      announcePolite={announcePolite}
+                    />
+                  );
+                })}
+              </div>
+            }
+          </React.Fragment>
+        )}
+      </LiveMessenger>
     );
   }
 }

--- a/src/components/current-query/index.js
+++ b/src/components/current-query/index.js
@@ -1,74 +1,31 @@
-import React from "react";
-import PropTypes from "prop-types";
-import queryString from "query-string";
-import moment from "moment";
-
-class FederatedCurrentQuery extends React.Component {
-
-	render() {
-		const { query } = this.props;
-
-    const fields = query.searchFields
-        .filter((searchField) => searchField.value && searchField.value.length > 0);
-
-    // Create a map of known facet type child components which can be rendered dynamically.
-    const facetTypes = {
-      "list-facet": ListFacetType,
-      "range-facet": RangeFacetType,
-      "text": TextFacetType
-    };
-
-		return (
-        <React.Fragment>
-          {fields.length > 0 && // Only render this if there are filters applied.
-            <div className="applied-filters">
-              <h2 className="element-invisible">Currently Applied Search
-                Filters.</h2>
-              <p className="element-invisible">Click a filter to remove it from
-                your search query.</p>
-              {fields.map((searchField, i) => {
-               // Determine which child component to render.
-                const MyFacetType = facetTypes[searchField.type];
-                return <MyFacetType key={i} searchField={searchField} {...this.props}/>
-              })}
-            </div>
-          }
-        </React.Fragment>
-		);
-	}
-}
-
-FederatedCurrentQuery.propTypes = {
-	onChange: PropTypes.func,
-	query: PropTypes.object
-};
+import React from 'react';
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+import moment from 'moment';
 
 // Create dumb component which can be configured by props.
-const FacetType = (props) => {
-  return (
-    <span className="applied-filters__filter" key={props.id} onClick={props.onClick}>
-			{props.children}
-		</span>
-  )
-};
+const FacetType = props => (
+  <span className="applied-filters__filter" key={props.id} onClick={props.onClick}>
+    {props.children}
+  </span>
+);
 
 // Configure and render the FacetType component to render as list facet type.
 class ListFacetType extends React.Component {
-
   removeListFacetValue(field, values, value) {
     const foundIdx = values.indexOf(value);
     // Get existing querystring params.
-    let parsed = queryString.parse(window.location.search);
+    const parsed = queryString.parse(window.location.search);
 
     // Those filter fields for which we want to preserve state in qs.
     // @todo handle parsing of terms and dates
     // @todo store this in app config?
     const filterFieldsWithQsState = [
-      "sm_site_name",
-      "ss_federated_type"
+      'sm_site_name',
+      'ss_federated_type',
     ];
 
-    const isQsParamField = filterFieldsWithQsState.find((item) => item === field );
+    const isQsParamField = filterFieldsWithQsState.find(item => item === field);
 
     if (foundIdx > -1) {
       if (isQsParamField) {
@@ -79,11 +36,9 @@ class ListFacetType extends React.Component {
         // Update the querystring params in the browser, add path to history.
         // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
         if (window.history.pushState) {
-          const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + stringified;
-          window.history.pushState({path: newurl}, '', newurl);
-          console.log(newurl)
-        }
-        else {
+          const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+          window.history.pushState({ path: newurl }, '', newurl);
+        } else {
           window.location.search = stringified;
         }
       }
@@ -94,56 +49,58 @@ class ListFacetType extends React.Component {
   }
 
   render() {
-    const {searchField} = this.props;
-    return ( searchField.value.map((val, i) => (
-        <FacetType key={i} id={i} onClick={() => this.removeListFacetValue(searchField.field, searchField.value, val)}>
-          {/* Add spacing to hierarchical facet values: Type>Term = Type > Term. */}
-          {val.replace('>',' > ')}
-        </FacetType>
-    )))
+    const { searchField } = this.props;
+    return (searchField.value.map((val, i) => (
+      <FacetType
+        key={i}
+        id={i}
+        onClick={() => this.removeListFacetValue(searchField.field, searchField.value, val)}
+      >
+        {/* Add spacing to hierarchical facet values: Type>Term = Type > Term. */}
+        {val.replace('>', ' > ')}
+      </FacetType>
+    )));
   }
 }
 
 // Configure and render the FacetType component to render as range facet type.
 class RangeFacetType extends React.Component {
-
   removeRangeFacetValue(field) {
     this.props.onChange(field, []);
   }
 
   render() {
-    const {searchField} = this.props;
+    const { searchField } = this.props;
     // Create a moment from the search start date.
     const start = moment(searchField.value[0]);
     // Use UTC.
     start.utc();
     // Create a formatted string from start date.
-    const startFormatted = start.format("MM/DD/YYYY");
+    const startFormatted = start.format('MM/DD/YYYY');
     // Create a moment from search end date.
     const end = moment(searchField.value[1]);
     // Use utc.
     end.utc();
     // Create a formatted string from end date.
-    const endFormatted = end.format("MM/DD/YYYY");
+    const endFormatted = end.format('MM/DD/YYYY');
     // Determine if we chose the same or different start / end dates.
-    const diff = start.diff(end,'days');
+    const diff = start.diff(end, 'days');
     // Only show the start date if the same date were chosen, otherwise: start - end.
-    const filterValue = diff ? startFormatted + ' - ' + endFormatted : startFormatted;
+    const filterValue = diff ? `${startFormatted} - ${endFormatted}` : startFormatted;
     return (
       <FacetType onClick={() => this.removeRangeFacetValue(searchField.field)}>
         {filterValue}
       </FacetType>
-    )
+    );
   }
 }
 
 // Configure and render the FacetType component to render as text facet type.
 class TextFacetType extends React.Component {
-
   removeTextValue(field) {
-    this.props.onChange(field, "");
+    this.props.onChange(field, '');
     // Get current querystring params.
-    let parsed = queryString.parse(window.location.search);
+    const parsed = queryString.parse(window.location.search);
     // Remove the search term param, if it exists.
     if (parsed.search) {
       delete parsed.search;
@@ -153,27 +110,66 @@ class TextFacetType extends React.Component {
     // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
     if (window.history.pushState) {
       if (stringified) {
-        const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + stringified;
-        window.history.pushState({path:newurl},'',newurl);
+        const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+        window.history.pushState({ path: newurl }, '', newurl);
+      } else {
+        const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+        window.history.pushState({ path: newurl }, '', newurl);
       }
-      else {
-        const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname;
-        window.history.pushState({path:newurl},'',newurl);
-      }
-    }
-    else {
+    } else {
       window.location.search = stringified;
     }
   }
 
   render() {
-    const {searchField} = this.props;
+    const { searchField } = this.props;
     return (
-        <FacetType onClick={() => this.removeTextValue(searchField.field)}>
-          {searchField.value}
-        </FacetType>
-    )
+      <FacetType onClick={() => this.removeTextValue(searchField.field)}>
+        {searchField.value}
+      </FacetType>
+    );
   }
 }
+
+class FederatedCurrentQuery extends React.Component {
+  render() {
+    const { query } = this.props;
+
+    const fields = query.searchFields.filter(searchField => searchField.value
+      && searchField.value.length > 0);
+
+    // Create a map of known facet type child components which can be rendered dynamically.
+    const facetTypes = {
+      'list-facet': ListFacetType,
+      'range-facet': RangeFacetType,
+      text: TextFacetType,
+    };
+
+    return (
+      <React.Fragment>
+        {fields.length > 0 && // Only render this if there are filters applied.
+          <div className="applied-filters">
+            <h2 className="element-invisible">
+              Currently Applied Search Filters.
+            </h2>
+            <p className="element-invisible">
+              Click a filter to remove it from your search query.
+            </p>
+            {fields.map((searchField, i) => {
+              // Determine which child component to render.
+              const MyFacetType = facetTypes[searchField.type];
+              return <MyFacetType key={i} searchField={searchField} {...this.props} />;
+            })}
+          </div>
+        }
+      </React.Fragment>
+    );
+  }
+}
+
+FederatedCurrentQuery.propTypes = {
+  onChange: PropTypes.func,
+  query: PropTypes.object,
+};
 
 export default FederatedCurrentQuery;

--- a/src/components/current-query/index.js
+++ b/src/components/current-query/index.js
@@ -5,9 +5,12 @@ import moment from 'moment';
 
 // Create dumb component which can be configured by props.
 const FacetType = props => (
-  <span className="applied-filters__filter" key={props.id} onClick={props.onClick}>
+  <button className="applied-filters__filter" key={props.id} onClick={props.onClick}>
+    <span className="element-invisible">
+      Remove filter
+    </span>
     {props.children}
-  </span>
+  </button>
 );
 
 // Configure and render the FacetType component to render as list facet type.

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -1,16 +1,17 @@
-import React from "react";
+import React from 'react';
 import PropTypes from 'prop-types';
-
+import FederatedSolrComponentPack from './federated_solr_component_pack';
 //import componentPack from "./component-pack";
-import FederatedSolrComponentPack from "./federated_solr_component_pack";
 
-const getFacetValues = (type, results, field, lowerBound, upperBound) =>
-    type === "period-range-facet" ? (results.facets[lowerBound] || []).concat(results.facets[upperBound] || []) :
-        type === "list-facet" || type === "range-facet" ? results.facets[field] || [] : null;
-
+const getFacetValues = (type, results, field, lowerBound, upperBound) => {
+  return type === 'period-range-facet'
+    ? (results.facets[lowerBound] || []).concat(results.facets[upperBound] || [])
+    : type === 'list-facet' || type === 'range-facet'
+      ? results.facets[field] || []
+      : null;
+};
 
 class FederatedSolrFacetedSearch extends React.Component {
-
   resetFilters() {
     let {query} = this.props;
     // Keep only the value of the main search field.
@@ -26,16 +27,22 @@ class FederatedSolrFacetedSearch extends React.Component {
   }
 
   render() {
-    const { customComponents, bootstrapCss, query, results, truncateFacetListsAt, options } = this.props;
-    const { onSearchFieldChange, onSortFieldChange, onPageChange } = this.props;
-
+    const {
+      customComponents,
+      bootstrapCss,
+      query,
+      results,
+      truncateFacetListsAt,
+      options,
+      onSearchFieldChange,
+      onTextInputChange,
+      onSortFieldChange,
+      onPageChange,
+    } = this.props;
     const { searchFields, sortFields, rows } = query;
     const start = query.start ? query.start : 0;
-
-
     const SearchFieldContainerComponent = customComponents.searchFields.container;
     const ResultContainerComponent = customComponents.results.container;
-
     const ResultComponent = customComponents.results.result;
     const ResultCount = customComponents.results.resultCount;
     const ResultHeaderComponent = customComponents.results.header;
@@ -45,15 +52,20 @@ class FederatedSolrFacetedSearch extends React.Component {
     const PreloadComponent = customComponents.results.preloadIndicator;
     const CurrentQueryComponent = customComponents.searchFields.currentQuery;
     const SortComponent = customComponents.sortFields.menu;
-    const resultPending = results.pending ? (<ResultPendingComponent bootstrapCss={bootstrapCss} />) : null;
     const FederatedTextSearch = FederatedSolrComponentPack.searchFields.text;
 
-    const pagination = query.pageStrategy === "paginate" ?
-        <PaginateComponent {...this.props} bootstrapCss={bootstrapCss} onChange={onPageChange} /> :
-        null;
+    const resultPending = results.pending
+      ? (<ResultPendingComponent bootstrapCss={bootstrapCss} />)
+      : null;
 
-    const preloadListItem = query.pageStrategy === "cursor" && results.docs.length < results.numFound ?
-        <PreloadComponent {...this.props} /> : null;
+    const pagination = query.pageStrategy === 'paginate' ?
+      <PaginateComponent {...this.props} bootstrapCss={bootstrapCss} onChange={onPageChange} /> :
+      null;
+
+    const preloadListItem = query.pageStrategy === 'cursor'
+    && results.docs.length < results.numFound
+      ? <PreloadComponent {...this.props} />
+      : null;
 
     let pageTitle;
     if (this.props.options.pageTitle != null) {
@@ -63,60 +75,90 @@ class FederatedSolrFacetedSearch extends React.Component {
     return (
         <div className="container">
           <aside className="l-25-75--1">
-            <SearchFieldContainerComponent bootstrapCss={bootstrapCss} onNewSearch={this.resetFilters.bind(this)} resultsCount={this.props.results.numFound}>
-              {searchFields.filter((searchFields) => this.props.sidebarFilters.indexOf(searchFields.field) > -1).map((searchField, i) => {
-                const { type, field, lowerBound, upperBound } = searchField;
-                const SearchComponent = customComponents.searchFields[type];
-                const facets = getFacetValues(type, results, field, lowerBound, upperBound);
+            <SearchFieldContainerComponent
+              bootstrapCss={bootstrapCss}
+              onNewSearch={this.resetFilters.bind(this)}
+              resultsCount={this.props.results.numFound}
+            >
+              {searchFields
+                .filter(searchField => this.props.sidebarFilters.indexOf(searchField.field) > -1)
+                .map((searchField, i) => {
+                  const {
+                    type,
+                    field,
+                    lowerBound,
+                    upperBound,
+                  } = searchField;
+                  const SearchComponent = customComponents.searchFields[type];
+                  const facets = getFacetValues(type, results, field, lowerBound, upperBound);
 
-                return (<SearchComponent
-                        key={i} {...this.props} {...searchField}
-                        bootstrapCss={bootstrapCss}
-                        facets={facets}
-                        truncateFacetListsAt={truncateFacetListsAt}
-                        onChange={onSearchFieldChange} />
-                );
-              })}
+                  return (
+                    <SearchComponent
+                      key={i}
+                      {...this.props}
+                      {...searchField}
+                      bootstrapCss={bootstrapCss}
+                      facets={facets}
+                      truncateFacetListsAt={truncateFacetListsAt}
+                      onChange={onSearchFieldChange}
+                    />
+                  );
+                })
+              }
             </SearchFieldContainerComponent>
           </aside>
           <div className="l-25-75--2">
             {pageTitle}
             <div className="search-form" autoComplete="on">
               <FederatedTextSearch
-                  autocomplete={options.autocomplete}
-                  field="tm_rendered_item"
-                  label="Enter search term:"
-                  onChange={onSearchFieldChange}
-                  value={searchFields.find((sf) => sf.field === "tm_rendered_item").value }
+                {...this.props}
+                autocomplete={options.autocomplete}
+                field="tm_rendered_item"
+                label="Enter search term:"
+                onSuggest={onTextInputChange}
+                onChange={onSearchFieldChange}
+                value={searchFields.find(sf => sf.field === 'tm_rendered_item').value }
               />
               <CurrentQueryComponent {...this.props} onChange={onSearchFieldChange} />
-              <SortComponent bootstrapCss={bootstrapCss} onChange={onSortFieldChange} sortFields={sortFields} />
+              <SortComponent
+                bootstrapCss={bootstrapCss}
+                onChange={onSortFieldChange}
+                sortFields={sortFields}
+              />
             </div>
-            <p className={(searchFields.find((sf) => sf.field === "tm_rendered_item").value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__prompt element-invisible' : 'solr-search-results-container__prompt'}>{this.props.options.searchPrompt || 'Please enter a search term.'}</p>
-            <div className={(searchFields.find((sf) => sf.field === "tm_rendered_item").value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__wrapper' : 'solr-search-results-container__wrapper element-invisible'}>
+            <p className={(searchFields.find(sf => sf.field === 'tm_rendered_item').value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__prompt element-invisible' : 'solr-search-results-container__prompt'}>{this.props.options.searchPrompt || 'Please enter a search term.'}</p>
+            <div className={(searchFields.find(sf => sf.field === 'tm_rendered_item').value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__wrapper' : 'solr-search-results-container__wrapper element-invisible'}>
               <ResultContainerComponent bootstrapCss={bootstrapCss}>
-              <ResultHeaderComponent bootstrapCss={bootstrapCss}>
-                <ResultCount bootstrapCss={bootstrapCss} numFound={results.numFound} start={start} rows={rows} onChange={onPageChange} noResultsText={this.props.options.noResults || null} />
-                {resultPending}
-              </ResultHeaderComponent>
-              <ResultListComponent bootstrapCss={bootstrapCss}>
-                {results.docs.map((doc, i) => (
-                    <ResultComponent bootstrapCss={bootstrapCss}
-                                     doc={doc}
-                                     fields={searchFields}
-                                     key={doc.id || i}
-                                     onSelect={this.props.onSelectDoc}
-                                     resultIndex={i}
-                                     rows={rows}
-                                     start={start}
-                                     highlight={results.highlighting[doc.id]}
-                                     hostname={this.props.options.hostname}
+                <ResultHeaderComponent bootstrapCss={bootstrapCss}>
+                  <ResultCount
+                    bootstrapCss={bootstrapCss}
+                    numFound={results.numFound}
+                    start={start}
+                    rows={rows}
+                    onChange={onPageChange}
+                    noResultsText={this.props.options.noResults || null}
+                  />
+                  {resultPending}
+                </ResultHeaderComponent>
+                <ResultListComponent bootstrapCss={bootstrapCss}>
+                  {results.docs.map((doc, i) => (
+                    <ResultComponent
+                      bootstrapCss={bootstrapCss}
+                      doc={doc}
+                      fields={searchFields}
+                      key={doc.id || i}
+                      onSelect={this.props.onSelectDoc}
+                      resultIndex={i}
+                      rows={rows}
+                      start={start}
+                      highlight={results.highlighting[doc.id]}
+                      hostname={this.props.options.hostname}
                     />
-                ))}
-                {preloadListItem}
-              </ResultListComponent>
-              {pagination}
-            </ResultContainerComponent>
+                  ))}
+                  {preloadListItem}
+                </ResultListComponent>
+                {pagination}
+              </ResultContainerComponent>
             </div>
           </div>
         </div>
@@ -127,16 +169,18 @@ class FederatedSolrFacetedSearch extends React.Component {
 FederatedSolrFacetedSearch.defaultProps = {
   bootstrapCss: true,
   customComponents: FederatedSolrComponentPack,
-  pageStrategy: "paginate",
+  pageStrategy: 'paginate',
   rows: 20,
   searchFields: [
-    {type: "text", field: "*"}
+    {
+      type: 'text', field: '*',
+    },
   ],
   sortFields: [],
   truncateFacetListsAt: -1,
   showCsvExport: false,
   sidebarFilters: ['sm_site_name', 'ss_federated_type', 'ds_federated_date', 'sm_federated_terms'],
-  options: {}
+  options: {},
 };
 
 FederatedSolrFacetedSearch.propTypes = {
@@ -146,13 +190,14 @@ FederatedSolrFacetedSearch.propTypes = {
   onNewSearch: PropTypes.func,
   onPageChange: PropTypes.func,
   onSearchFieldChange: PropTypes.func.isRequired,
+  onTextInputChange: PropTypes.func,
   onSelectDoc: PropTypes.func,
   onSortFieldChange: PropTypes.func.isRequired,
   query: PropTypes.object,
   results: PropTypes.object,
   showCsvExport: PropTypes.bool,
   truncateFacetListsAt: PropTypes.number,
-  options: PropTypes.object
+  options: PropTypes.object,
 };
 
 export default FederatedSolrFacetedSearch;

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -121,7 +121,10 @@ class FederatedSolrFacetedSearch extends React.Component {
                 onChange={onSearchFieldChange}
                 value={searchFields.find(sf => sf.field === 'tm_rendered_item').value}
               />
-              <CurrentQueryComponent {...this.props} onChange={onSearchFieldChange} />
+              <CurrentQueryComponent
+                {...this.props}
+                onChange={onSearchFieldChange}
+              />
               <SortComponent
                 bootstrapCss={bootstrapCss}
                 onChange={onSortFieldChange}

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { LiveAnnouncer, LiveMessage } from 'react-aria-live';
 import FederatedSolrComponentPack from './federated_solr_component_pack';
 //import componentPack from "./component-pack";
 
@@ -73,6 +74,7 @@ class FederatedSolrFacetedSearch extends React.Component {
     }
 
     return (
+      <LiveAnnouncer>
         <div className="container">
           <aside className="l-25-75--1">
             <SearchFieldContainerComponent
@@ -117,7 +119,7 @@ class FederatedSolrFacetedSearch extends React.Component {
                 label="Enter search term:"
                 onSuggest={onTextInputChange}
                 onChange={onSearchFieldChange}
-                value={searchFields.find(sf => sf.field === 'tm_rendered_item').value }
+                value={searchFields.find(sf => sf.field === 'tm_rendered_item').value}
               />
               <CurrentQueryComponent {...this.props} onChange={onSearchFieldChange} />
               <SortComponent
@@ -137,6 +139,7 @@ class FederatedSolrFacetedSearch extends React.Component {
                     rows={rows}
                     onChange={onPageChange}
                     noResultsText={this.props.options.noResults || null}
+                    termValue={searchFields.find(sf => sf.field === 'tm_rendered_item').value}
                   />
                   {resultPending}
                 </ResultHeaderComponent>
@@ -162,6 +165,7 @@ class FederatedSolrFacetedSearch extends React.Component {
             </div>
           </div>
         </div>
+      </LiveAnnouncer>
     );
   }
 }

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LiveAnnouncer, LiveMessage } from 'react-aria-live';
+import { LiveAnnouncer } from 'react-aria-live';
 import FederatedSolrComponentPack from './federated_solr_component_pack';
 //import componentPack from "./component-pack";
 

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -26,7 +26,7 @@ class FederatedSolrFacetedSearch extends React.Component {
   }
 
   render() {
-    const { customComponents, bootstrapCss, query, results, truncateFacetListsAt } = this.props;
+    const { customComponents, bootstrapCss, query, results, truncateFacetListsAt, options } = this.props;
     const { onSearchFieldChange, onSortFieldChange, onPageChange } = this.props;
 
     const { searchFields, sortFields, rows } = query;
@@ -83,6 +83,7 @@ class FederatedSolrFacetedSearch extends React.Component {
             {pageTitle}
             <div className="search-form" autoComplete="on">
               <FederatedTextSearch
+                  autocomplete={options.autocomplete}
                   field="tm_rendered_item"
                   label="Enter search term:"
                   onChange={onSearchFieldChange}

--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
-import React from "react";
-import cx from "classnames";
-import queryString from "query-string";
+import React from 'react';
+import cx from 'classnames';
+import queryString from 'query-string';
 import AnimateHeight from 'react-animate-height';
 
 
@@ -11,22 +11,22 @@ class FederatedListFacet extends React.Component {
     super(props);
 
     this.state = {
-      filter: "",
-      truncateFacetListsAt: props.truncateFacetListsAt
+      filter: '',
+      truncateFacetListsAt: props.truncateFacetListsAt,
     };
   }
 
   handleClick(value) {
     const foundIdx = this.props.value.indexOf(value);
     // Get existing querystring params.
-    let parsed = queryString.parse(window.location.search);
+    const parsed = queryString.parse(window.location.search);
 
     // Those filter fields for which we want to preserve state in qs.
     // @todo handle parsing of terms and dates
     // @todo store this in app config?
     const filterFieldsWithQsState = [
-      "sm_site_name",
-      "ss_federated_type"
+      'sm_site_name',
+      'ss_federated_type',
     ];
 
     const isQsParamField = filterFieldsWithQsState.find((item) => item === this.props.field);
@@ -39,8 +39,7 @@ class FederatedListFacet extends React.Component {
 
       // Send new query based on app state.
       this.props.onChange(this.props.field, this.props.value.concat(value));
-    }
-    else {
+    } else {
       if (isQsParamField) {
         // Remove the param for this field from the parsed qs object.
         delete parsed[this.props.field];
@@ -56,11 +55,9 @@ class FederatedListFacet extends React.Component {
       // Update the querystring params in the browser, add path to history.
       // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
       if (window.history.pushState) {
-        const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + stringified;
-        window.history.pushState({path: newurl}, '', newurl);
-        console.log(newurl)
-      }
-      else {
+        const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+        window.history.pushState({ path: newurl }, '', newurl);
+      } else {
         window.location.search = stringified;
       }
     }
@@ -71,12 +68,12 @@ class FederatedListFacet extends React.Component {
     // If this is a hierarchical list facet.
     if (hierarchyFacetValue) {
       // Determine the current state of the expanded hierarchical list facets.
-      const indexOfExpandedHierarchyFacetValue = this.props.expandedHierarchies.indexOf(hierarchyFacetValue);
+      const indexOfExpandedHierarchyFacetValue = this.props.expandedHierarchies
+        .indexOf(hierarchyFacetValue);
       if (indexOfExpandedHierarchyFacetValue > -1) {
         // This accordion is currently expanded, so collapse it.
         this.props.expandedHierarchies.splice(indexOfExpandedHierarchyFacetValue,1);
-      }
-      else {
+      } else {
         // This accordion is currently collapsed, so expand it.
         this.props.expandedHierarchies.push(hierarchyFacetValue);
       }
@@ -84,14 +81,21 @@ class FederatedListFacet extends React.Component {
   }
 
   render() {
-    const { label, facets, field, value, collapse, hierarchy } = this.props;
+    const {
+      label,
+      facets,
+      field,
+      value,
+      collapse,
+      hierarchy,
+    } = this.props;
     const { truncateFacetListsAt } = this.state;
 
     const facetCounts = facets.filter((facet, i) => i % 2 === 1);
     const facetValues = facets.filter((facet, i) => i % 2 === 0);
     // Create an object of facets {value: count} to keep consistent for inputs.
     const facetInputs = {};
-    facetValues.forEach((value, i) => {
+    facetValues.forEach((v, i) => {
       const key = facetValues[i];
       facetInputs[key] = facetCounts[i];
     });
@@ -99,7 +103,8 @@ class FederatedListFacet extends React.Component {
     const expanded = !(collapse || false);
     const height = expanded ? 'auto' : 0;
 
-    // If we need to generate multiple list-fact accordion groups from this list-facet field (i.e. sm_federated_terms).
+    // If we need to generate multiple list-fact accordion groups
+    // from this list-facet field (i.e. sm_federated_terms).
     if (hierarchy) {
       // Iterate through sm_federated_terms array of values.
       // Each value is a string with the format Type>Term.
@@ -124,60 +129,72 @@ class FederatedListFacet extends React.Component {
         // If we don't already have terms.Type then create it.
         if (!Object.hasOwnProperty.call(terms, pieces[0])) {
           terms[pieces[0]] = {};
-          terms[pieces[0]]['items'] = [];
-          terms[pieces[0]]['expanded'] = (this.props.expandedHierarchies.indexOf(pieces[0]) > -1);
-          terms[pieces[0]]['height'] = terms[pieces[0]]['expanded'] ? 'auto' : 0;
+          terms[pieces[0]].items = [];
+          terms[pieces[0]].expanded = (this.props.expandedHierarchies.indexOf(pieces[0]) > -1);
+          terms[pieces[0]].height = terms[pieces[0]].expanded ? 'auto' : 0;
         }
         // Add the object for this facet value to the array of terms for this type.
-        terms[pieces[0]]['items'].push({term: pieces[1], facetValue: facetValue, facetCount: facetCounts[i]});
+        terms[pieces[0]].items.push({
+          term: pieces[1],
+          facetValue,
+          facetCount: facetCounts[i],
+        });
       });
 
       // Remove duplicate types
       // So facet values of "Condition>Bones", "Condition>Bone growth" should only
       // Add "Condition" type once so we only render 1 Condition accordion group.
-      const uniqueTypes = types.filter((value, index, self) => self.indexOf(value) === index).filter(String);
+      const uniqueTypes = types.filter((v, i, self) => self.indexOf(v) === i).filter(String);
 
       // Define array of accordion Lis which we'll populate with react fragments.
-      let listFacetHierarchyLis = [];
+      const listFacetHierarchyLis = [];
       // Define array of checkbox Lis which we'll populate with react fragments, per type.
-      let listFacetHierarchyTermsLis = [];
+      const listFacetHierarchyTermsLis = [];
       // Iterate through types (accordion lis).
       uniqueTypes.forEach((type, i) => {
         // Populate the checkbox lis react fragments for each type.
         listFacetHierarchyTermsLis[type] = [];
-        terms[type]['items'].forEach((termObj, i) => termObj.facetCount && listFacetHierarchyTermsLis[type].push(
-          <li key={`${termObj.term}_${termObj.facetValue}_${i}`}>
+        terms[type].items.forEach((termObj, i) => termObj.facetCount
+          && listFacetHierarchyTermsLis[type].push(<li key={`${termObj.term}_${termObj.facetValue}_${i}`}>
             <label className="search-accordion__checkbox-label">
             <input
-                type="checkbox"
-                name={type}
-                value={termObj.facetValue}
-                checked={value.indexOf(termObj.facetValue) > -1}
-                onChange={() => this.handleClick(termObj.facetValue)}
+              type="checkbox"
+              name={type}
+              value={termObj.facetValue}
+              checked={value.indexOf(termObj.facetValue) > -1}
+              onChange={() => this.handleClick(termObj.facetValue)}
             /> {termObj.term}
-            <span className="facet-item-amount"> ({termObj.facetCount})</span>
-          </label>
-        </li>));
+              <span className="facet-item-amount"> ({termObj.facetCount}
+                <span className="element-invisible">results</span>)
+              </span>
+            </label>
+          </li>));
 
         // Populate the accordion lis array with all of its checkboxes.
         listFacetHierarchyTermsLis[type].length && listFacetHierarchyLis.push(
           <li id={`solr-list-facet-${type}`} key={`solr-list-facet-${type}-${i}`}>
             <a
               tabIndex="0"
-              className={cx("search-accordion__title", {"js-search-accordion-open": terms[type]['expanded']})}
+              className={cx('search-accordion__title', { 'js-search-accordion-open': terms[type].expanded })}
               id={label.replace(/\s+/g, '-').toLowerCase()}
               onClick={this.toggleExpand.bind(this, type)}
-            >{type}</a>
+              onKeyDown={(event) => {
+                if (event.keyCode === 13) {
+                  this.toggleExpand(type);
+                }
+              }}
+            >
+              <span className="element-invisible">Toggle filter group for</span> {type}
+            </a>
             <AnimateHeight
               duration={600}
-              height={terms[type]['height']}
+              height={terms[type].height}
             >
               <ul className="search-accordion__content" key={`solr-list-facet-${type}-ul`}>
                 {listFacetHierarchyTermsLis[type]}
               </ul>
             </AnimateHeight>
-          </li>
-        );
+          </li>);
       });
       // Render the group of accordion lis with their facet value checkbox lists.
       return listFacetHierarchyLis;
@@ -187,17 +204,23 @@ class FederatedListFacet extends React.Component {
     return (
       <li id={`solr-list-facet-${field}`}>
         <a
-            tabIndex="0"
-            className={cx("search-accordion__title", {"js-search-accordion-open": expanded})}
-            id={label.replace(/\s+/g, '-').toLowerCase()}
-            onClick={this.toggleExpand.bind(this)}
+          tabIndex="0"
+          className={cx('search-accordion__title', { 'js-search-accordion-open': expanded })}
+          id={label.replace(/\s+/g, '-').toLowerCase()}
+          onClick={this.toggleExpand.bind(this)}
         >{label}</a>
         <AnimateHeight
           duration={600}
           height={height}
         >
           <ul className="search-accordion__content" key={`solr-list-facet-${field}-ul`}>
-            {facetValues.filter((facetValue, i) => facetInputs[facetValue] > 0 && (truncateFacetListsAt < 0 || i < truncateFacetListsAt)).map((facetValue, i) => this.state.filter.length === 0 || facetValue.toLowerCase().indexOf(this.state.filter.toLowerCase()) > -1 ? (<li key={`${facetValue}_${facetInputs[facetValue]}`}>
+            {facetValues.filter((facetValue, i) => facetInputs[facetValue] > 0
+                && (truncateFacetListsAt < 0 || i < truncateFacetListsAt))
+              .map((facetValue, i) => {
+                if (this.state.filter.length === 0
+                  || facetValue.toLowerCase().indexOf(this.state.filter.toLowerCase()) > -1) {
+                  return (
+                    <li key={`${facetValue}_${facetInputs[facetValue]}`}>
               <label className="search-accordion__checkbox-label">
               <input
                 type="checkbox"
@@ -208,7 +231,11 @@ class FederatedListFacet extends React.Component {
               /> {facetValue}
               <span className="facet-item-amount"> ({facetInputs[facetValue]})</span>
             </label>
-            </li>) : null)}
+                    </li>
+                  );
+                }
+                return null;
+              })}
           </ul>
         </AnimateHeight>
       </li>
@@ -219,7 +246,7 @@ class FederatedListFacet extends React.Component {
 FederatedListFacet.defaultProps = {
   hierarchy: false,
   expandedHierarchies: [],
-  value: []
+  value: [],
 };
 
 FederatedListFacet.propTypes = {
@@ -237,7 +264,7 @@ FederatedListFacet.propTypes = {
   onSetCollapse: PropTypes.func,
   query: PropTypes.object,
   truncateFacetListsAt: PropTypes.number,
-  value: PropTypes.array
+  value: PropTypes.array,
 };
 
 export default FederatedListFacet;

--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -208,7 +208,14 @@ class FederatedListFacet extends React.Component {
           className={cx('search-accordion__title', { 'js-search-accordion-open': expanded })}
           id={label.replace(/\s+/g, '-').toLowerCase()}
           onClick={this.toggleExpand.bind(this)}
-        >{label}</a>
+          onKeyDown={(event) => {
+            if (event.keyCode === 13) {
+              this.toggleExpand();
+            }
+          }}
+        >
+          <span className="element-invisible">Toggle filter group for</span> {label}
+        </a>
         <AnimateHeight
           duration={600}
           height={height}
@@ -221,16 +228,18 @@ class FederatedListFacet extends React.Component {
                   || facetValue.toLowerCase().indexOf(this.state.filter.toLowerCase()) > -1) {
                   return (
                     <li key={`${facetValue}_${facetInputs[facetValue]}`}>
-              <label className="search-accordion__checkbox-label">
-              <input
-                type="checkbox"
-                name={field}
-                value={facetValue}
-                checked={value.indexOf(facetValue) > -1 ? true : false}
-                onChange={() => this.handleClick(facetValue)}
-              /> {facetValue}
-              <span className="facet-item-amount"> ({facetInputs[facetValue]})</span>
-            </label>
+                      <label className="search-accordion__checkbox-label">
+                        <input
+                          type="checkbox"
+                          name={field}
+                          value={facetValue}
+                          checked={value.indexOf(facetValue) > -1}
+                          onChange={() => this.handleClick(facetValue)}
+                        /> {facetValue}
+                        <span className="facet-item-amount"> ({facetInputs[facetValue]}
+                          <span className="element-invisible">results</span>)
+                        </span>
+                      </label>
                     </li>
                   );
                 }

--- a/src/components/range-facet/index.js
+++ b/src/components/range-facet/index.js
@@ -84,6 +84,7 @@ class FederatedRangeFacet extends React.Component {
           className={cx("search-accordion__title", {"js-search-accordion-open": expanded})}
           id={label.replace(/\s+/g, '-').toLowerCase()}
           onClick={this.toggleExpand.bind(this)}
+          onKeyDown={(event)=>{if (event.keyCode === 13) {this.toggleExpand()}}}
         >{label}</a>
         <AnimateHeight
           duration={600}

--- a/src/components/results/_pagination.scss
+++ b/src/components/results/_pagination.scss
@@ -2,7 +2,7 @@
  * pagination.scss
  * Define pagination styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-pager {
   background-color: transparent;

--- a/src/components/results/_pagination.scss
+++ b/src/components/results/_pagination.scss
@@ -2,7 +2,7 @@
  * pagination.scss
  * Define pagination styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-pager {
   background-color: transparent;

--- a/src/components/results/_search-results-stat.scss
+++ b/src/components/results/_search-results-stat.scss
@@ -2,7 +2,7 @@
  * search-results-stat.scss
  * Define search results statistic styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 .search-results-stat {

--- a/src/components/results/_search-results-stat.scss
+++ b/src/components/results/_search-results-stat.scss
@@ -2,7 +2,7 @@
  * search-results-stat.scss
  * Define search results statistic styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-results-stat {

--- a/src/components/results/_search-results.scss
+++ b/src/components/results/_search-results.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search results styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 .search-results {

--- a/src/components/results/_search-results.scss
+++ b/src/components/results/_search-results.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search results styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-results {

--- a/src/components/results/count-label.js
+++ b/src/components/results/count-label.js
@@ -11,8 +11,7 @@ function searchResultsStat(currentPage, numFound, rows, pageAmt, noResultsText, 
     message = (
       <span>Showing page
         <b> {currentPage + 1}</b> of
-        <b> {pageAmt}</b>
-        (<b> {numFound}</b> results).
+        <b> {pageAmt}</b> (<b>{numFound}</b> results).
       </span>
     );
   } else if (numFound <= rows && numFound > 1) { // Single page

--- a/src/components/results/count-label.js
+++ b/src/components/results/count-label.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LiveMessage } from 'react-aria-live';
-import helpers from '../../helpers';
 
 function searchResultsStat(currentPage, numFound, rows, pageAmt, noResultsText, termValue) {
   // Set visible and a11y message based on query results.
@@ -9,13 +8,19 @@ function searchResultsStat(currentPage, numFound, rows, pageAmt, noResultsText, 
   let a11yMessage = '';
   if (numFound > rows) { // Many pages
     a11yMessage = `Showing page ${currentPage + 1} of ${pageAmt} (${numFound} results).`;
-    message = [`${currentPage + 1}`, `${pageAmt}`, `${numFound}`].reduce((acc, item) => helpers.highlightText(acc, item), a11yMessage);
+    message = (
+      <span>Showing page
+        <b> {currentPage + 1}</b> of
+        <b> {pageAmt}</b>
+        (<b> {numFound}</b> results).
+      </span>
+    );
   } else if (numFound <= rows && numFound > 1) { // Single page
     a11yMessage = `Showing ${numFound} results.`;
-    message = helpers.highlightText(a11yMessage, numFound);
+    message = (<span>Showing <b>{numFound}</b> results.</span>);
   } else if (numFound === 1) { // Single item
     a11yMessage = `Showing ${numFound} result.`;
-    message = helpers.highlightText(a11yMessage, numFound);
+    message = (<span>Showing <b>{numFound}</b> result.</span>);
   } else if (numFound === 0) { // No results
     message = noResultsText || 'Sorry, your search yielded no results.';
     a11yMessage = message;

--- a/src/components/sort-menu/_search-scope.scss
+++ b/src/components/sort-menu/_search-scope.scss
@@ -2,7 +2,7 @@
  * search-scope.scss
  * Define search scope styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-scope {

--- a/src/components/sort-menu/_search-scope.scss
+++ b/src/components/sort-menu/_search-scope.scss
@@ -2,7 +2,7 @@
  * search-scope.scss
  * Define search scope styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 .search-scope {

--- a/src/components/text-search/_autocomplete.scss
+++ b/src/components/text-search/_autocomplete.scss
@@ -1,0 +1,93 @@
+/**
+ * autocomplete.scss
+ * Define autocomplete input + suggestion styles.
+ * @see: https://github.com/moroshko/react-autosuggest#theme-optional
+ *
+ * @copyright Copyright (c) 2017 Palantir.net
+ */
+
+.search-form__autocomplete-container {
+  display: flex;
+
+  @include breakpoint($bp1) {
+    width: 75%;
+  }
+
+  @include breakpoint($bp3) {
+    width: 50%;
+  }
+
+  .search-form__input-wrapper {
+    width: 100%;
+  }
+}
+
+.react-autosuggest {
+  &__container {
+    position: relative;
+    flex: 1;
+  }
+
+  &__input {
+    @include adjust-font-size-to($label, .8);
+    flex: 1;
+    border: 1px solid $gray-light;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    height: 34px;
+    padding: .5rem;
+
+    &:focus {
+      border-color: $gray-dark;
+      outline: none;
+    }
+
+    .react-autosuggest__container--open & {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  &__suggestions-container {
+    display: none;
+  }
+
+  &__suggestions-container--open {
+    display: block;
+    position: absolute;
+    top: 33px;
+    width: 100%;
+    border: 1px solid $gray-dark;
+    background-color: $white;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    z-index: 2;
+  }
+
+  &__suggestions-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  &__suggestion {
+    @include adjust-font-size-to($label, .8);
+    cursor: pointer;
+    padding: 10px 20px;
+    background-color: $white;
+    border: 1px solid $white;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+
+  &__suggestion-link {
+    color: $link-color;
+  }
+
+  &__suggestion--highlighted {
+    background-color: $c-bg-gray;
+    border: 1px solid $c-bg-gray;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+}

--- a/src/components/text-search/_autocomplete.scss
+++ b/src/components/text-search/_autocomplete.scss
@@ -3,7 +3,7 @@
  * Define autocomplete input + suggestion styles.
  * @see: https://github.com/moroshko/react-autosuggest#theme-optional
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-form__autocomplete-container {

--- a/src/components/text-search/_autocomplete.scss
+++ b/src/components/text-search/_autocomplete.scss
@@ -76,8 +76,11 @@
     padding: 10px 20px;
     background-color: $white;
     border: 1px solid $white;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+
+    &:last-child {
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+    }
   }
 
   &__suggestion-link {
@@ -87,7 +90,5 @@
   &__suggestion--highlighted {
     background-color: $c-bg-gray;
     border: 1px solid $c-bg-gray;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
   }
 }

--- a/src/components/text-search/_autocomplete.scss
+++ b/src/components/text-search/_autocomplete.scss
@@ -52,6 +52,40 @@
     display: none;
   }
 
+  &__container-title {
+    @include adjust-font-size-to($label, .8);
+    position: relative;
+    font-weight: bold;
+    padding: 10px 20px;
+    border-bottom: 1px dashed $c-border-gray;
+  }
+
+  &__container-close-button {
+    @include adjust-font-size-to($label, .8);
+    font-style: normal;
+    padding: 3px 7px;
+    border-color: $c-border-gray;
+    color: $gray-dark;
+    cursor: pointer;
+    position: absolute;
+    right: 5px;
+
+    &:hover {
+      border-color: $c-border-gray-dark;
+      background-color: $c-bg-gray;
+    }
+  }
+
+  &__container-directions {
+    padding: 10px 20px;
+
+    &-item {
+      @include adjust-font-size-to($label, .8);
+      display: block;
+    }
+
+  }
+
   &__suggestions-container--open {
     display: block;
     position: absolute;
@@ -63,6 +97,15 @@
     border-bottom-right-radius: 4px;
     z-index: 2;
   }
+  &__suggestions-itemslist-wrapper--with-directions {
+    .react-autosuggest__suggestion {
+      &:last-child {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        border-bottom-color: $c-border-gray;
+      }
+    }
+  }
 
   &__suggestions-list {
     margin: 0;
@@ -73,13 +116,15 @@
   &__suggestion {
     @include adjust-font-size-to($label, .8);
     cursor: pointer;
-    padding: 10px 20px;
+    padding: 15px 20px;
     background-color: $white;
     border: 1px solid $white;
+    border-bottom-color: $c-border-gray;
 
     &:last-child {
       border-bottom-left-radius: 4px;
       border-bottom-right-radius: 4px;
+      border-bottom-color: $white;
     }
   }
 
@@ -90,5 +135,6 @@
   &__suggestion--highlighted {
     background-color: $c-bg-gray;
     border: 1px solid $c-bg-gray;
+    border-bottom-color: $c-border-gray;
   }
 }

--- a/src/components/text-search/_autocomplete.scss
+++ b/src/components/text-search/_autocomplete.scss
@@ -3,7 +3,7 @@
  * Define autocomplete input + suggestion styles.
  * @see: https://github.com/moroshko/react-autosuggest#theme-optional
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 .search-form__autocomplete-container {

--- a/src/components/text-search/_search-form.scss
+++ b/src/components/text-search/_search-form.scss
@@ -44,6 +44,11 @@
   @include breakpoint($bp2) {
     padding: .35rem;
   }
+
+  &:focus {
+    border-color: $gray-dark;
+    outline: none;
+  }
 }
 
 .search-form__submit {

--- a/src/components/text-search/_search-form.scss
+++ b/src/components/text-search/_search-form.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-form {

--- a/src/components/text-search/_search-form.scss
+++ b/src/components/text-search/_search-form.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 .search-form {

--- a/src/components/text-search/index.js
+++ b/src/components/text-search/index.js
@@ -1,98 +1,13 @@
-import PropTypes from 'prop-types';
-import queryString from 'query-string';
 import React from 'react';
-import SearchIcon from '../icons/search';
+import FederatedTextSearchNoAutocomplete from './no-autocomplete';
+import FederatedTextSearchAsYouType from './search-as-you-type';
 
-
-class FederatedTextSearch extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      value: '',
-    };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      value: nextProps.value,
-    });
-
-    this.handleInputChange = this.handleInputChange.bind(this);
-    this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
-
-  handleInputChange(ev) {
-    this.setState({
-      value: ev.target.value,
-    });
-  }
-
-  handleInputKeyDown(ev) {
-    if (ev.keyCode === 13) {
-      this.handleSubmit();
-    }
-  }
-
-  handleSubmit() {
-    this.props.onChange(this.props.field, this.state.value);
-    // Get existing querystring params.
-    const parsed = queryString.parse(window.location.search);
-    // Update the search querystring param with the value from the search field.
-    parsed.search = this.state.value;
-    const stringified = queryString.stringify(parsed);
-    // Update the querystring params in the browser, add path to history.
-    // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
-    if (window.history.pushState) {
-      const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
-      window.history.pushState({ path: newUrl }, '', newUrl);
-    } else {
-      window.location.search = stringified;
-    }
-  }
-
-  render() {
-    const { label } = this.props;
-
-    return (
-      <React.Fragment>
-        <label htmlFor="search" className="search-form__label">{label}</label>
-        <div className="search-form__input-wrapper">
-          <input
-            type="search"
-            name="search"
-            id="search"
-            className="search-form__input"
-            autoFocus
-            onChange={this.handleInputChange}
-            onKeyDown={this.handleInputKeyDown}
-            value={this.state.value || ''}
-          />
-          <button
-            type="submit"
-            className="search-form__submit"
-            onClick={this.handleSubmit}>
-            <span className="element-invisible">Perform Search</span>
-            <SearchIcon />
-          </button>
-        </div>
-      </React.Fragment>
-    );
-  }
-}
-
-FederatedTextSearch.defaultProps = {
-  label: '',
-  onChange: () => {},
-  value: '',
-};
-
-FederatedTextSearch.propTypes = {
-  field: PropTypes.string.isRequired,
-  label: PropTypes.string,
-  onChange: PropTypes.func,
-  value: PropTypes.string,
+const FederatedTextSearch = (props) => {
+  const { autocomplete } = props;
+  const InputComponent = autocomplete
+    ? FederatedTextSearchAsYouType
+    : FederatedTextSearchNoAutocomplete;
+  return <InputComponent {...props} />
 };
 
 export default FederatedTextSearch;

--- a/src/components/text-search/index.js
+++ b/src/components/text-search/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
-import queryString from "query-string";
-import React from "react";
-import SearchIcon from "../icons/search";
+import queryString from 'query-string';
+import React from 'react';
+import SearchIcon from '../icons/search';
 
 
 class FederatedTextSearch extends React.Component {
@@ -9,19 +9,23 @@ class FederatedTextSearch extends React.Component {
     super(props);
 
     this.state = {
-      value: ""
+      value: '',
     };
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      value: nextProps.value
+      value: nextProps.value,
     });
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   handleInputChange(ev) {
     this.setState({
-      value: ev.target.value
+      value: ev.target.value,
     });
   }
 
@@ -34,17 +38,16 @@ class FederatedTextSearch extends React.Component {
   handleSubmit() {
     this.props.onChange(this.props.field, this.state.value);
     // Get existing querystring params.
-    let parsed = queryString.parse(window.location.search);
+    const parsed = queryString.parse(window.location.search);
     // Update the search querystring param with the value from the search field.
     parsed.search = this.state.value;
     const stringified = queryString.stringify(parsed);
     // Update the querystring params in the browser, add path to history.
     // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
     if (window.history.pushState) {
-      const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + stringified;
-      window.history.pushState({path:newurl},'',newurl);
-    }
-    else {
+      const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+      window.history.pushState({ path: newUrl }, '', newUrl);
+    } else {
       window.location.search = stringified;
     }
   }
@@ -56,11 +59,23 @@ class FederatedTextSearch extends React.Component {
       <React.Fragment>
         <label htmlFor="search" className="search-form__label">{label}</label>
         <div className="search-form__input-wrapper">
-          <input type="search" name="search" id="search" className="search-form__input" autoFocus
-                 onChange={this.handleInputChange.bind(this)}
-                 onKeyDown={this.handleInputKeyDown.bind(this)}
-                 value={this.state.value || ""} />
-          <button type="submit" className="search-form__submit" onClick={this.handleSubmit.bind(this)}><span className="element-invisible">Perform Search</span><SearchIcon /></button>
+          <input
+            type="search"
+            name="search"
+            id="search"
+            className="search-form__input"
+            autoFocus
+            onChange={this.handleInputChange}
+            onKeyDown={this.handleInputKeyDown}
+            value={this.state.value || ''}
+          />
+          <button
+            type="submit"
+            className="search-form__submit"
+            onClick={this.handleSubmit}>
+            <span className="element-invisible">Perform Search</span>
+            <SearchIcon />
+          </button>
         </div>
       </React.Fragment>
     );
@@ -68,13 +83,16 @@ class FederatedTextSearch extends React.Component {
 }
 
 FederatedTextSearch.defaultProps = {
-  field: null
+  label: '',
+  onChange: () => {},
+  value: '',
 };
 
 FederatedTextSearch.propTypes = {
   field: PropTypes.string.isRequired,
   label: PropTypes.string,
   onChange: PropTypes.func,
+  value: PropTypes.string,
 };
 
 export default FederatedTextSearch;

--- a/src/components/text-search/index.js
+++ b/src/components/text-search/index.js
@@ -7,7 +7,7 @@ const FederatedTextSearch = (props) => {
   const InputComponent = autocomplete
     ? FederatedTextSearchAsYouType
     : FederatedTextSearchNoAutocomplete;
-  return <InputComponent {...props} />
+  return <InputComponent {...props} />;
 };
 
 export default FederatedTextSearch;

--- a/src/components/text-search/no-autocomplete.js
+++ b/src/components/text-search/no-autocomplete.js
@@ -3,7 +3,9 @@ import queryString from 'query-string';
 import React from 'react';
 import SearchIcon from '../icons/search';
 
-
+// Renders plain text input and submit button for text search.
+// Rendered when env config autocomplete is not present or set to false.
+// @see /env.local.js.example
 class FederatedTextSearchNoAutocomplete extends React.Component {
   constructor(props) {
     super(props);
@@ -11,16 +13,16 @@ class FederatedTextSearchNoAutocomplete extends React.Component {
     this.state = {
       value: '',
     };
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({
       value: nextProps.value,
     });
-
-    this.handleInputChange = this.handleInputChange.bind(this);
-    this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   handleInputChange(ev) {

--- a/src/components/text-search/no-autocomplete.js
+++ b/src/components/text-search/no-autocomplete.js
@@ -1,0 +1,98 @@
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+import React from 'react';
+import SearchIcon from '../icons/search';
+
+
+class FederatedTextSearchNoAutocomplete extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: '',
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      value: nextProps.value,
+    });
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleInputChange(ev) {
+    this.setState({
+      value: ev.target.value,
+    });
+  }
+
+  handleInputKeyDown(ev) {
+    if (ev.keyCode === 13) {
+      this.handleSubmit();
+    }
+  }
+
+  handleSubmit() {
+    this.props.onChange(this.props.field, this.state.value);
+    // Get existing querystring params.
+    const parsed = queryString.parse(window.location.search);
+    // Update the search querystring param with the value from the search field.
+    parsed.search = this.state.value;
+    const stringified = queryString.stringify(parsed);
+    // Update the querystring params in the browser, add path to history.
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
+    if (window.history.pushState) {
+      const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+      window.history.pushState({ path: newUrl }, '', newUrl);
+    } else {
+      window.location.search = stringified;
+    }
+  }
+
+  render() {
+    const { label } = this.props;
+
+    return (
+      <React.Fragment>
+        <label htmlFor="search" className="search-form__label">{label}</label>
+        <div className="search-form__input-wrapper">
+          <input
+            type="search"
+            name="search"
+            id="search"
+            className="search-form__input"
+            autoFocus
+            onChange={this.handleInputChange}
+            onKeyDown={this.handleInputKeyDown}
+            value={this.state.value || ''}
+          />
+          <button
+            type="submit"
+            className="search-form__submit"
+            onClick={this.handleSubmit}>
+            <span className="element-invisible">Perform Search</span>
+            <SearchIcon />
+          </button>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+FederatedTextSearchNoAutocomplete.defaultProps = {
+  label: '',
+  onChange: () => {},
+  value: '',
+};
+
+FederatedTextSearchNoAutocomplete.propTypes = {
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  onChange: PropTypes.func,
+  value: PropTypes.string,
+};
+
+export default FederatedTextSearchNoAutocomplete;

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -34,6 +34,7 @@ class FederatedTextSearchAsYouType extends React.Component {
     this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(this);
     this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(this);
     this.renderSuggestion = this.renderSuggestion.bind(this);
+    this.renderSuggestionsContainer = this.renderSuggestionsContainer.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -157,6 +158,32 @@ class FederatedTextSearchAsYouType extends React.Component {
     }
   }
 
+  renderSuggestionsContainer({ containerProps, children, query }) {
+    const { mode, directionsText } = this.props.autocomplete;
+    const titleText = this.props.autocomplete[mode].titleText || 'What are you looking for?';
+    const suggestionsWrapperClasses = directionsText
+      ? 'react-autosuggest__suggestions-itemslist-wrapper react-autosuggest__suggestions-itemslist-wrapper--with-directions'
+      : 'react-autosuggest__suggestions-itemslist-wrapper';
+
+    return (
+      <div {... containerProps}>
+        <div className="react-autosuggest__container-title">
+          {titleText}
+          <button className="react-autosuggest__container-close-button" onClick={this.onSuggestionsClearRequested}>x</button>
+        </div>
+        <div className={suggestionsWrapperClasses}>
+          {children}
+        </div>
+        {directionsText &&
+          <div className="react-autosuggest__container-directions">
+            <span className="react-autosuggest__container-directions-item">Press <code>ENTER</code> to search for <strong>{query}</strong> or <code>ESC</code> to close.</span>
+            <span className="react-autosuggest__container-directions-item">Press ↑ and ↓ to highlight a suggestion then <code>ENTER</code> to be redirected to that suggestion.</span>
+          </div>
+        }
+      </div>
+    );
+  }
+
   /**
    * Define how suggestions are rendered.
    * Note: must be a pure function.
@@ -243,6 +270,7 @@ class FederatedTextSearchAsYouType extends React.Component {
             onSuggestionSelected={this.onSuggestionSelected}
             renderInputComponent={FederatedTextSearchAsYouType.renderInputComponent}
             renderSuggestion={this.renderSuggestion}
+            renderSuggestionsContainer={this.renderSuggestionsContainer}
             shouldRenderSuggestions={FederatedTextSearchAsYouType.shouldRenderSuggestions}
             suggestions={suggestions}
           />
@@ -266,12 +294,16 @@ FederatedTextSearchAsYouType.defaultProps = {
 };
 
 FederatedTextSearchAsYouType.propTypes = {
-  autocomplete: PropTypes.shape({
-    mode: PropTypes.string,
-    method: PropTypes.string,
-    url: PropTypes.string,
-    queryField: PropTypes.string,
-  }).isRequired,
+  autocomplete: PropTypes.oneOfType([
+    PropTypes.shape({
+      mode: PropTypes.string,
+      method: PropTypes.string,
+      url: PropTypes.string,
+      queryField: PropTypes.string,
+      directionsText: PropTypes.bool,
+    }),
+    PropTypes.bool,
+  ]).isRequired,
   field: PropTypes.string.isRequired,
   label: PropTypes.string,
   onChange: PropTypes.func.isRequired,

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -167,8 +167,9 @@ class FederatedTextSearchAsYouType extends React.Component {
   }
 
   renderSuggestionsContainer({ containerProps, children, query }) {
-    const { mode, directionsText } = this.props.autocomplete;
+    const { mode } = this.props.autocomplete;
     const titleText = this.props.autocomplete[mode].titleText || 'What are you looking for?';
+    const directionsText = this.props.autocomplete[mode].directionsText || true;
     const suggestionsWrapperClasses = directionsText
       ? 'react-autosuggest__suggestions-itemslist-wrapper react-autosuggest__suggestions-itemslist-wrapper--with-directions'
       : 'react-autosuggest__suggestions-itemslist-wrapper';
@@ -182,6 +183,7 @@ class FederatedTextSearchAsYouType extends React.Component {
         <div className={suggestionsWrapperClasses}>
           {children}
         </div>
+        {/* @todo add logic for suggestion mode and alter directionsText accordingly */}
         {directionsText &&
           <div className="react-autosuggest__container-directions">
             <span className="react-autosuggest__container-directions-item">Press <code>ENTER</code> to search for <strong>{query}</strong> or <code>ESC</code> to close.</span>

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -10,13 +10,6 @@ import SearchIcon from '../icons/search';
 // Rendered when env config autocomplete is present.
 // @see /env.local.js.example
 class FederatedTextSearchAsYouType extends React.Component {
-  // When the input is focused, Autosuggest will consult this function
-  // when to render suggestions. Use it, for example, if you want to
-  // display suggestions when input value is at least 2 characters long.
-  static shouldRenderSuggestions(value) {
-    return value.trim().length >= 2;
-  }
-
   constructor(props) {
     super(props);
 
@@ -35,6 +28,7 @@ class FederatedTextSearchAsYouType extends React.Component {
     this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(this);
     this.renderSuggestion = this.renderSuggestion.bind(this);
     this.renderSuggestionsContainer = this.renderSuggestionsContainer.bind(this);
+    this.shouldRenderSuggestions = this.shouldRenderSuggestions.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -166,6 +160,14 @@ class FederatedTextSearchAsYouType extends React.Component {
     }
   }
 
+  // When the input is focused, Autosuggest will consult this function
+  // when to render suggestions. Use it, for example, if you want to
+  // display suggestions when input value is at least 2 characters long.
+  shouldRenderSuggestions(value) {
+    const numChars = this.props.autocomplete.numChars || 2;
+    return value.trim().length > numChars;
+  }
+
   renderSuggestionsContainer({ containerProps, children, query }) {
     const { mode } = this.props.autocomplete;
     const titleText = this.props.autocomplete[mode].titleText || 'What are you looking for?';
@@ -287,7 +289,7 @@ class FederatedTextSearchAsYouType extends React.Component {
             renderInputComponent={FederatedTextSearchAsYouType.renderInputComponent}
             renderSuggestion={this.renderSuggestion}
             renderSuggestionsContainer={this.renderSuggestionsContainer}
-            shouldRenderSuggestions={FederatedTextSearchAsYouType.shouldRenderSuggestions}
+            shouldRenderSuggestions={this.shouldRenderSuggestions}
             suggestQuery={suggestQuery}
             suggestions={suggestions}
           />
@@ -320,7 +322,12 @@ FederatedTextSearchAsYouType.propTypes = {
       method: PropTypes.string,
       url: PropTypes.string,
       queryField: PropTypes.string,
-      directionsText: PropTypes.bool,
+      suggestionRows: PropTypes.number,
+      numChars: PropTypes.number,
+      result: {
+        titleText: PropTypes.string,
+        directionsText: PropTypes.bool,
+      },
     }),
     PropTypes.bool,
   ]).isRequired,

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -229,7 +229,7 @@ class FederatedTextSearchAsYouType extends React.Component {
     // Render plain text for search term suggestions.
     // @todo update this when we have a return structure for terms.
     if (mode === 'term') {
-      return <span>highlightedTitle</span>;
+      return (<span>highlightedTitle</span>);
     }
 
     // Defaults to result based autosuggestion.

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -130,12 +130,17 @@ class FederatedTextSearchAsYouType extends React.Component {
     this.props.onSuggest(this.props.autocomplete, value);
   }
 
-  // Call submit handler when enter is pressed while text input
-  // has focused.  This functionality is prevented by the
-  // onSuggestionSelected method.
   handleInputKeyDown(event) {
+    // Call submit handler when enter is pressed while text input
+    // has focused.  This functionality is prevented by the
+    // onSuggestionSelected method.
     if (event.keyCode === 13 && !event.defaultPrevented) {
       this.handleSubmit();
+    }
+
+    // Clear and close suggetsions.
+    if (event.keyCode === 27) {
+      this.onSuggestionsClearRequested();
     }
   }
 

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -6,7 +6,7 @@ import Autosuggest from 'react-autosuggest';
 import helpers from '../../helpers';
 import SearchIcon from '../icons/search';
 
-// Renders autcomplete text input and submit button for text search.
+// Renders autocomplete text input and submit button for text search.
 // Rendered when env config autocomplete is present.
 // @see /env.local.js.example
 class FederatedTextSearchAsYouType extends React.Component {
@@ -170,8 +170,26 @@ class FederatedTextSearchAsYouType extends React.Component {
 
   renderSuggestionsContainer({ containerProps, children, query }) {
     const { mode } = this.props.autocomplete;
-    const titleText = this.props.autocomplete[mode].titleText || 'What are you looking for?';
-    const directionsText = this.props.autocomplete[mode].directionsText || true;
+    const hasResultModeConfig = Object.hasOwnProperty.call(this.props.autocomplete, 'result');
+    const hasTermModeConfig = Object.hasOwnProperty.call(this.props.autocomplete, 'term');
+    const resultTitleText = hasResultModeConfig && this.props.autocomplete.result.titleText
+      ? this.props.autocomplete.result.titleText
+      : 'What are you looking for?';
+    const resultShowDirectionsText = hasResultModeConfig
+      && this.props.autocomplete.result.showDirectionsText
+      ? this.props.autocomplete.result.showDirectionsText
+      : true;
+    const termTitleText = hasTermModeConfig && this.props.autocomplete.term.titleText
+      ? this.props.autocomplete.term.titleText
+      : 'Suggested search terms';
+    const termShowDirectionsText = hasTermModeConfig
+      && this.props.autocomplete.term.showDirectionsText
+      ? this.props.autocomplete.term.showDirectionsText
+      : true;
+
+    const titleText = mode === 'term' ? termTitleText : resultTitleText;
+    const directionsText = mode === 'term' ? termShowDirectionsText : resultShowDirectionsText;
+
     const suggestionsWrapperClasses = directionsText
       ? 'react-autosuggest__suggestions-itemslist-wrapper react-autosuggest__suggestions-itemslist-wrapper--with-directions'
       : 'react-autosuggest__suggestions-itemslist-wrapper';
@@ -324,7 +342,11 @@ FederatedTextSearchAsYouType.propTypes = {
       numChars: PropTypes.number,
       result: {
         titleText: PropTypes.string,
-        directionsText: PropTypes.bool,
+        showDirectionsText: PropTypes.bool,
+      },
+      term: {
+        titleText: PropTypes.string,
+        showDirectionsText: PropTypes.bool,
       },
     }),
     PropTypes.bool,

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -1,0 +1,208 @@
+import React from 'react';
+import queryString from 'query-string';
+import PropTypes from 'prop-types';
+import Autosuggest from 'react-autosuggest';
+import SearchIcon from '../icons/search';
+
+class FederatedTextSearchAsYouType extends React.Component {
+  // When the input is focused, Autosuggest will consult this function
+  // when to render suggestions. Use it, for example, if you want to
+  // display suggestions when input value is at least 2 characters long.
+  static shouldRenderSuggestions(value) {
+    return value.trim().length >= 2;
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: '',
+      suggestions: [],
+    };
+
+    this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.loadSuggestions = this.loadSuggestions.bind(this);
+    this.onChange = this.onChange.bind(this);
+    this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(this);
+    this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(this);
+    this.renderSuggestion = this.renderSuggestion.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      value: nextProps.value,
+    });
+  }
+
+  /**
+   *
+   * @param event
+   *   called every time the input value changes
+   * @param newValue
+   *   the new value of the input
+   * @param method
+   *   string describing how the change has occurred. The possible values are:
+   *   'down' - user pressed Down
+   *   'up' - user pressed Up
+   *   'escape' - user pressed Escape
+   *   'enter' - user pressed Enter
+   *   'click' - user clicked (or tapped) on suggestion
+   *   'type' - none of the methods above (usually means that user typed something,
+   *     but can also be that they pressed Backspace, pasted something into the input, etc.)
+   */
+  onChange(event, { newValue, method }) {
+    if (method === 'type') {
+      this.setState({
+        value: newValue,
+      });
+    }
+  }
+
+  // Will be called every time you need to recalculate suggestions.
+  onSuggestionsFetchRequested({ value }) {
+    this.loadSuggestions(value);
+  }
+
+  // Will be called every time suggestion is selected via mouse or keyboard.
+  static onSuggestionSelected(event, suggestion) {
+    if (event.keyCode === 13) {
+      event.preventDefault(); // don't submit the search query
+      window.location.replace(suggestion.suggestion.sm_urls[0]); // redirect to the selected item
+    }
+  }
+
+  // Will be called every time you need to set suggestions to [].
+  onSuggestionsClearRequested() {
+    this.setState({
+      suggestions: [],
+    });
+  }
+
+  static getSuggestionValue(suggestion) {
+    return suggestion;
+  }
+
+  // Gets search suggestions based on input.
+  loadSuggestions(value) {
+    const { url, queryField } = this.props.autocomplete;
+
+    fetch(`${url}?q=${value}&rows=10&df=${queryField}&wt=json`)
+      .then(response => response.json())
+      .then((responseJson) => {
+        this.setState({
+          suggestions: responseJson.response.docs,
+        });
+      });
+  }
+
+  // Calls submit handler when enter is pressed while text input
+  // has focused.  This functionality is overridden in the
+  // onSuggestionSelected method.
+  handleInputKeyDown(ev) {
+    if (ev.keyCode === 13) {
+      this.handleSubmit();
+    }
+  }
+
+  // Triggers search query execution by updating the current URL based
+  // on current state.
+  handleSubmit() {
+    this.props.onChange(this.props.field, this.state.value);
+    // Get existing querystring params.
+    const parsed = queryString.parse(window.location.search);
+    // Update the search querystring param with the value from the search field.
+    parsed.search = this.state.value;
+    const stringified = queryString.stringify(parsed);
+    // Update the querystring params in the browser, add path to history.
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
+    if (window.history.pushState) {
+      const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+      window.history.pushState({ path: newUrl }, '', newUrl);
+    } else {
+      window.location.search = stringified;
+    }
+  }
+
+  renderSuggestion(suggestion) {
+    const { autocomplete } = this.props;
+    return (
+      <a
+        className="react-autosuggest__suggestion-link"
+        href={suggestion.sm_urls[0]}
+        dangerouslySetInnerHTML={{ __html: suggestion.ss_federated_title }}
+      />
+    );
+  }
+
+  static renderInputComponent(inputProps) {
+    return (
+      <div className="search-form__input-wrapper">
+        <input {...inputProps} />
+      </div>
+    );
+  }
+
+  render() {
+    const { label } = this.props;
+    const { suggestions } = this.state;
+    const inputProps = {
+      type: 'search',
+      name: 'search',
+      id: 'search',
+      className: 'react-autosuggest__input',
+      onChange: this.onChange,
+      onKeyDown: this.handleInputKeyDown,
+      value: this.state.value || '',
+    };
+
+    return (
+      <React.Fragment>
+        <label htmlFor="search" className="search-form__label">{label}</label>
+        <div className="search-form__autocomplete-container">
+          {/* @see: https://github.com/moroshko/react-autosuggest#react-autosuggest */}
+          <Autosuggest
+            focusInputOnSuggestionClick={false}
+            getSuggestionValue={FederatedTextSearchAsYouType.getSuggestionValue}
+            inputProps={inputProps}
+            onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+            onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+            onSuggestionSelected={FederatedTextSearchAsYouType.onSuggestionSelected}
+            renderInputComponent={FederatedTextSearchAsYouType.renderInputComponent}
+            renderSuggestion={this.renderSuggestion}
+            shouldRenderSuggestions={FederatedTextSearchAsYouType.shouldRenderSuggestions}
+            suggestions={suggestions}
+          />
+          <button
+            type="submit"
+            className="search-form__submit"
+            onClick={this.handleSubmit}
+          >
+            <span className="element-invisible">Perform Search</span>
+            <SearchIcon />
+          </button>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+FederatedTextSearchAsYouType.defaultProps = {
+  label: 'Enter a search term',
+  onChange: () => {},
+  value: '',
+};
+
+FederatedTextSearchAsYouType.propTypes = {
+  autocomplete: PropTypes.shape({
+    method: PropTypes.string,
+    url: PropTypes.string,
+    queryField: PropTypes.string,
+  }).isRequired,
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  onChange: PropTypes.func,
+  value: PropTypes.string,
+};
+
+export default FederatedTextSearchAsYouType;

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -31,7 +31,8 @@ class FederatedTextSearchAsYouType extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      value: nextProps.value,
+      value: nextProps.suggestQuery ? nextProps.suggestQuery.value : nextProps.value,
+      suggestions: nextProps.suggestions ? nextProps.suggestions.docs : this.state.suggestions,
     });
   }
 
@@ -59,7 +60,7 @@ class FederatedTextSearchAsYouType extends React.Component {
     }
   }
 
-  // Will be called every time you need to recalculate suggestions.
+  // Called every time you need to recalculate suggestions.
   onSuggestionsFetchRequested({ value }) {
     this.loadSuggestions(value);
   }
@@ -84,16 +85,10 @@ class FederatedTextSearchAsYouType extends React.Component {
   }
 
   // Gets search suggestions based on input.
+  // @todo support different modes: term, results
   loadSuggestions(value) {
-    const { url, queryField } = this.props.autocomplete;
-
-    fetch(`${url}?q=${value}&rows=10&df=${queryField}&wt=json`)
-      .then(response => response.json())
-      .then((responseJson) => {
-        this.setState({
-          suggestions: responseJson.response.docs,
-        });
-      });
+    // Run typeahead search query based on the autocomplete config and current value.
+    this.props.onSuggest(this.props.autocomplete, value);
   }
 
   // Calls submit handler when enter is pressed while text input
@@ -105,7 +100,7 @@ class FederatedTextSearchAsYouType extends React.Component {
     }
   }
 
-  // Triggers search query execution by updating the current URL based
+  // Trigger search query execution by updating the current URL based
   // on current state.
   handleSubmit() {
     this.props.onChange(this.props.field, this.state.value);
@@ -145,7 +140,8 @@ class FederatedTextSearchAsYouType extends React.Component {
 
   render() {
     const { label } = this.props;
-    const { suggestions } = this.state;
+    const { suggestions, value } = this.state;
+    // Define props for autocomplete input element.
     const inputProps = {
       type: 'search',
       name: 'search',
@@ -153,7 +149,7 @@ class FederatedTextSearchAsYouType extends React.Component {
       className: 'react-autosuggest__input',
       onChange: this.onChange,
       onKeyDown: this.handleInputKeyDown,
-      value: this.state.value || '',
+      value: value || '',
     };
 
     return (
@@ -202,6 +198,7 @@ FederatedTextSearchAsYouType.propTypes = {
   field: PropTypes.string.isRequired,
   label: PropTypes.string,
   onChange: PropTypes.func,
+  onSuggest: PropTypes.func.isRequired,
   value: PropTypes.string,
 };
 

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -213,7 +213,7 @@ class FederatedTextSearchAsYouType extends React.Component {
    * unused - isHighlighted
    * Whether or not the suggestion is highlighted.
    *
-   * @return a string or a ReactElement
+   * @return a ReactElement
    */
   renderSuggestion(suggestion, { query }) {
     // Determine if we are returning results or terms. @todo or both
@@ -226,27 +226,25 @@ class FederatedTextSearchAsYouType extends React.Component {
     const currentHumanIndex = this.state.suggestions.indexOf(suggestion) + 1;
     const suggestionsLength = this.state.suggestions.length;
 
-    // Render a link for search result suggestions.
-    if (mode === 'result') {
-      return (
-        <a
-          className="react-autosuggest__suggestion-link"
-          href={suggestion.sm_urls[0]}
-        >
-          {highlightedTitle}
-          <span className="element-invisible">
-            {` (${currentHumanIndex} of ${suggestionsLength})`}
-          </span>
-        </a>
-      );
-    }
-
     // Render plain text for search term suggestions.
     // @todo update this when we have a return structure for terms.
     if (mode === 'term') {
-      return highlightedTitle;
+      return <span>highlightedTitle</span>;
     }
-    return suggestion;
+
+    // Defaults to result based autosuggestion.
+    // Render a link for search result suggestions.
+    return (
+      <a
+        className="react-autosuggest__suggestion-link"
+        href={suggestion.sm_urls[0]}
+      >
+        {highlightedTitle}
+        <span className="element-invisible">
+          {` (${currentHumanIndex} of ${suggestionsLength})`}
+        </span>
+      </a>
+    );
   }
 
   // Wrap the input component with our expected wrapper.

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -215,6 +215,9 @@ class FederatedTextSearchAsYouType extends React.Component {
     const decodedTitle = he.decode(suggestion.ss_federated_title);
     // Wrap the query partial string in <b>.
     const highlightedTitle = helpers.highlightText(decodedTitle, query);
+    // Define a11y message i.e. (1 of 3) to append to suggestion text.
+    const currentHumanIndex = this.state.suggestions.indexOf(suggestion) + 1;
+    const suggestionsLength = this.state.suggestions.length;
 
     // Render a link for search result suggestions.
     if (mode === 'result') {
@@ -224,6 +227,9 @@ class FederatedTextSearchAsYouType extends React.Component {
           href={suggestion.sm_urls[0]}
         >
           {highlightedTitle}
+          <span className="element-invisible">
+            {` (${currentHumanIndex} of ${suggestionsLength})`}
+          </span>
         </a>
       );
     }

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -66,6 +66,9 @@ class FederatedTextSearchAsYouType extends React.Component {
       this.setState({
         value: newValue,
       });
+
+      // Ensure that the suggestQuery.value prop gets cleared on backspace / cut.
+      this.props.suggestQuery.value = newValue;
     }
   }
 
@@ -127,7 +130,7 @@ class FederatedTextSearchAsYouType extends React.Component {
   // @todo support different modes: term, results
   loadSuggestions(value) {
     // Run typeahead search query based on the autocomplete config and current value.
-    this.props.onSuggest(this.props.autocomplete, value);
+    this.props.onSuggest(this.props.query, this.props.autocomplete, value);
   }
 
   handleInputKeyDown(event) {
@@ -252,7 +255,7 @@ class FederatedTextSearchAsYouType extends React.Component {
   }
 
   render() {
-    const { label } = this.props;
+    const { label, suggestQuery } = this.props;
     const { suggestions, value } = this.state;
     // Define props for autocomplete input element.
     const inputProps = {
@@ -283,6 +286,7 @@ class FederatedTextSearchAsYouType extends React.Component {
             renderSuggestion={this.renderSuggestion}
             renderSuggestionsContainer={this.renderSuggestionsContainer}
             shouldRenderSuggestions={FederatedTextSearchAsYouType.shouldRenderSuggestions}
+            suggestQuery={suggestQuery}
             suggestions={suggestions}
           />
           <button
@@ -302,6 +306,9 @@ class FederatedTextSearchAsYouType extends React.Component {
 FederatedTextSearchAsYouType.defaultProps = {
   label: 'Enter a search term',
   value: '',
+  suggestQuery: {
+    value: '',
+  },
 };
 
 FederatedTextSearchAsYouType.propTypes = {
@@ -319,6 +326,9 @@ FederatedTextSearchAsYouType.propTypes = {
   label: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onSuggest: PropTypes.func.isRequired,
+  suggestQuery: PropTypes.shape({
+    value: PropTypes.string,
+  }),
   value: PropTypes.string,
 };
 

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -222,14 +222,14 @@ class FederatedTextSearchAsYouType extends React.Component {
    *   The suggestion to render
    *
    * @param query
-   * Used to highlight the matching string. As user types in the input,
-   * query will be equal to the trimmed value of the input. Then, if user
-   * interacts using the Up or Down keys, the input will get the value of
-   * the highlighted suggestion, but query will remain to be equal to the
-   * trimmed value of the input prior to the Up and Down interactions.
+   *   Used to highlight the matching string. As user types in the input,
+   *   query will be equal to the trimmed value of the input. Then, if user
+   *   interacts using the Up or Down keys, the input will get the value of
+   *   the highlighted suggestion, but query will remain to be equal to the
+   *   trimmed value of the input prior to the Up and Down interactions.
    *
    * unused - isHighlighted
-   * Whether or not the suggestion is highlighted.
+   *   Whether or not the suggestion is highlighted.
    *
    * @return a ReactElement
    */

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -65,11 +65,33 @@ class FederatedTextSearchAsYouType extends React.Component {
     this.loadSuggestions(value);
   }
 
-  // Will be called every time suggestion is selected via mouse or keyboard.
-  static onSuggestionSelected(event, suggestion) {
-    if (event.keyCode === 13) {
+  /**
+   * Called every time suggestion is selected via mouse or keyboard.
+   *
+   * @param event
+   *   Event object
+   * @param suggestion
+   *   The selected suggestion
+   *   Unused: suggestionValue
+   *     The value of the selected suggestion
+   *     (equivalent to getSuggestionValue(suggestion))
+   *   Unused: suggestionIndex
+   *     The index of the selected suggestion in the suggestions array
+   *   Unused: sectionIndex
+   *     When rendering multiple sections,this will be the section index
+   *     (in suggestions) of the selected suggestion. Otherwise, it will be null.
+   * @param method
+   *   String describing how user selected the suggestion. The possible values are:
+   *     'click' - user clicked (or tapped) on the suggestion
+   *     'enter' - user selected the suggestion using Enter
+   */
+  onSuggestionSelected(event, { suggestion, method }) {
+    const { mode } = this.props.autocomplete;
+    // If results are rendered, redirect to the result url and prevent search execution.
+    if (mode === 'result' && (event.keyCode === 13 || method === 'click')) {
       event.preventDefault(); // don't submit the search query
-      window.location.replace(suggestion.suggestion.sm_urls[0]); // redirect to the selected item
+      event.stopPropagation(); // don't bubble up event
+      window.location.assign(suggestion.sm_urls[0]); // redirect to the selected item
     }
   }
 
@@ -91,11 +113,11 @@ class FederatedTextSearchAsYouType extends React.Component {
     this.props.onSuggest(this.props.autocomplete, value);
   }
 
-  // Calls submit handler when enter is pressed while text input
-  // has focused.  This functionality is overridden in the
+  // Call submit handler when enter is pressed while text input
+  // has focused.  This functionality is prevented by the
   // onSuggestionSelected method.
-  handleInputKeyDown(ev) {
-    if (ev.keyCode === 13) {
+  handleInputKeyDown(event) {
+    if (event.keyCode === 13 && !event.defaultPrevented) {
       this.handleSubmit();
     }
   }
@@ -191,6 +213,7 @@ FederatedTextSearchAsYouType.defaultProps = {
 
 FederatedTextSearchAsYouType.propTypes = {
   autocomplete: PropTypes.shape({
+    mode: PropTypes.string,
     method: PropTypes.string,
     url: PropTypes.string,
     queryField: PropTypes.string,

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -225,6 +225,8 @@ class FederatedTextSearchAsYouType extends React.Component {
       onChange: this.onChange,
       onKeyDown: this.handleInputKeyDown,
       value: value || '',
+      role: 'combobox',
+      'aria-autocomplete': 'both',
     };
 
     return (

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -3,25 +3,25 @@ import React from 'react';
 /**
  * Find and highlight relevant keywords within a block of text
  * @param  {string} text - The text to parse
- * @param  {string} value - The search keyword to highlight
+ * @param  {string} highlight - The search keyword/partial to highlight
  * @return {object} A JSX object containing an array of alternating strings and JSX
  */
-const highlightText = (text, value) => {
-  if (!value) {
-    return text;
+const highlightText = (text, highlight) => {
+  if (!highlight.toString().trim()) {
+    return <span>{text}</span>;
   }
-  return (<span>
-    { text.split(value)
-      .reduce((prev, current, i) => {
-        if (!i) {
-          return [current];
-        }
-        return prev.concat(<b key={value + current}>{ value }</b>, current);
-      }, [])
-    }
-  </span>);
+  // Split on highlight term and include term into parts, ignore case
+  const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
+  return (
+    <span> { parts.map((part, i) =>
+      (
+        <span key={i} style={part.toLowerCase() === highlight.toString().toLowerCase() ? { fontWeight: 'bold' } : {}}>
+          { part }
+        </span>
+      ))}
+    </span>);
 };
 
 export default {
   highlightText,
-}
+};

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+/**
+ * Find and highlight relevant keywords within a block of text
+ * @param  {string} text - The text to parse
+ * @param  {string} value - The search keyword to highlight
+ * @return {object} A JSX object containing an array of alternating strings and JSX
+ */
+const highlightText = (text, value) => {
+  if (!value) {
+    return text;
+  }
+  return (<span>
+    { text.split(value)
+      .reduce((prev, current, i) => {
+        if (!i) {
+          return [current];
+        }
+        return prev.concat(<b key={value + current}>{ value }</b>, current);
+      }, [])
+    }
+  </span>);
+};
+
+export default {
+  highlightText,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,7 @@ const init = (settings) => {
     rows: 20,
     // Hostname overridable in ./.env.local.js for testing purposes.
     hostname: window.location.hostname,
+    autocomplete: false,
   };
 
   const options = Object.assign(defaults, settings);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1154,6 +1154,9 @@ textarea {
   @media (min-width: 900px) {
     .search-form__input {
       padding: .35rem; } }
+  .search-form__input:focus {
+    border-color: #333;
+    outline: none; }
 
 .search-form__submit {
   padding: .5rem .7rem;
@@ -1174,6 +1177,81 @@ textarea {
     height: 1em;
     width: 1em;
     fill: #fff; }
+
+/**
+ * autocomplete.scss
+ * Define autocomplete input + suggestion styles.
+ * @see: https://github.com/moroshko/react-autosuggest#theme-optional
+ *
+ * @copyright Copyright (c) 2017 Palantir.net
+ */
+.search-form__autocomplete-container {
+  display: flex; }
+  @media (min-width: 600px) {
+    .search-form__autocomplete-container {
+      width: 75%; } }
+  @media (min-width: 1100px) {
+    .search-form__autocomplete-container {
+      width: 50%; } }
+  .search-form__autocomplete-container .search-form__input-wrapper {
+    width: 100%; }
+
+.react-autosuggest__container {
+  position: relative;
+  flex: 1; }
+
+.react-autosuggest__input {
+  font-size: 0.8em;
+  line-height: 1.46667em;
+  flex: 1;
+  border: 1px solid #e5e5e5;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  height: 34px;
+  padding: .5rem; }
+  .react-autosuggest__input:focus {
+    border-color: #333;
+    outline: none; }
+  .react-autosuggest__container--open .react-autosuggest__input {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0; }
+
+.react-autosuggest__suggestions-container {
+  display: none; }
+
+.react-autosuggest__suggestions-container--open {
+  display: block;
+  position: absolute;
+  top: 33px;
+  width: 100%;
+  border: 1px solid #333;
+  background-color: #fff;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  z-index: 2; }
+
+.react-autosuggest__suggestions-list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none; }
+
+.react-autosuggest__suggestion {
+  font-size: 0.8em;
+  line-height: 1.46667em;
+  cursor: pointer;
+  padding: 10px 20px;
+  background-color: #fff;
+  border: 1px solid #fff; }
+  .react-autosuggest__suggestion:last-child {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px; }
+
+.react-autosuggest__suggestion-link {
+  color: #737373; }
+
+.react-autosuggest__suggestion--highlighted {
+  background-color: #f6f6f6;
+  border: 1px solid #f6f6f6; }
 
 /**
  * search-form.scss

--- a/src/styles.css
+++ b/src/styles.css
@@ -1117,7 +1117,7 @@ textarea {
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-form {
   margin-bottom: 2.93333em; }
@@ -1183,7 +1183,7 @@ textarea {
  * Define autocomplete input + suggestion styles.
  * @see: https://github.com/moroshko/react-autosuggest#theme-optional
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-form__autocomplete-container {
   display: flex; }
@@ -1294,7 +1294,7 @@ textarea {
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-filters__trigger,
 .search-accordion__title {
@@ -1482,7 +1482,7 @@ textarea {
  * aside.scss
  * Define aside styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 aside {
   margin-bottom: 1.46667em;
@@ -1495,7 +1495,7 @@ aside {
  * search-form.scss
  * Define search results styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-results li {
   margin-bottom: 1.46667em;
@@ -1569,7 +1569,7 @@ aside {
  * search-scope.scss
  * Define search scope styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-scope {
   margin: 1.46667em 0; }
@@ -1663,7 +1663,7 @@ aside {
  * pagination.scss
  * Define pagination styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-pager {
   background-color: transparent; }
@@ -1754,7 +1754,7 @@ aside {
  * search-results-stat.scss
  * Define search results statistic styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-results-stat {
   font-size: 0.9em;
@@ -1767,7 +1767,7 @@ aside {
  * applied-filters.scss
  * Define applied filters styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .applied-filters {
   margin: 1.46667em 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1219,6 +1219,35 @@ textarea {
 .react-autosuggest__suggestions-container {
   display: none; }
 
+.react-autosuggest__container-title {
+  font-size: 0.8em;
+  line-height: 1.46667em;
+  position: relative;
+  font-weight: bold;
+  padding: 10px 20px;
+  border-bottom: 1px dashed #ccc; }
+
+.react-autosuggest__container-close-button {
+  font-size: 0.8em;
+  line-height: 1.46667em;
+  font-style: normal;
+  padding: 3px 7px;
+  border-color: #ccc;
+  color: #333;
+  cursor: pointer;
+  position: absolute;
+  right: 5px; }
+  .react-autosuggest__container-close-button:hover {
+    border-color: #b5b5b5;
+    background-color: #f6f6f6; }
+
+.react-autosuggest__container-directions {
+  padding: 10px 20px; }
+  .react-autosuggest__container-directions-item {
+    font-size: 0.8em;
+    line-height: 1.46667em;
+    display: block; }
+
 .react-autosuggest__suggestions-container--open {
   display: block;
   position: absolute;
@@ -1230,6 +1259,11 @@ textarea {
   border-bottom-right-radius: 4px;
   z-index: 2; }
 
+.react-autosuggest__suggestions-itemslist-wrapper--with-directions .react-autosuggest__suggestion:last-child {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-color: #ccc; }
+
 .react-autosuggest__suggestions-list {
   margin: 0;
   padding: 0;
@@ -1239,19 +1273,22 @@ textarea {
   font-size: 0.8em;
   line-height: 1.46667em;
   cursor: pointer;
-  padding: 10px 20px;
+  padding: 15px 20px;
   background-color: #fff;
-  border: 1px solid #fff; }
+  border: 1px solid #fff;
+  border-bottom-color: #ccc; }
   .react-autosuggest__suggestion:last-child {
     border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px; }
+    border-bottom-right-radius: 4px;
+    border-bottom-color: #fff; }
 
 .react-autosuggest__suggestion-link {
   color: #737373; }
 
 .react-autosuggest__suggestion--highlighted {
   background-color: #f6f6f6;
-  border: 1px solid #f6f6f6; }
+  border: 1px solid #f6f6f6;
+  border-bottom-color: #ccc; }
 
 /**
  * search-form.scss
@@ -1740,6 +1777,7 @@ aside {
   font-size: 0.8em;
   line-height: 1.46667em;
   padding-bottom: 0.29333em;
+  border: 0;
   border-bottom: solid 2px #0000ff;
   margin-right: 0.73333em;
   margin-bottom: 0.73333em;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1117,7 +1117,7 @@ textarea {
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-form {
   margin-bottom: 2.93333em; }
@@ -1183,7 +1183,7 @@ textarea {
  * Define autocomplete input + suggestion styles.
  * @see: https://github.com/moroshko/react-autosuggest#theme-optional
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-form__autocomplete-container {
   display: flex; }
@@ -1294,7 +1294,7 @@ textarea {
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-filters__trigger,
 .search-accordion__title {
@@ -1482,7 +1482,7 @@ textarea {
  * aside.scss
  * Define aside styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 aside {
   margin-bottom: 1.46667em;
@@ -1495,7 +1495,7 @@ aside {
  * search-form.scss
  * Define search results styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-results li {
   margin-bottom: 1.46667em;
@@ -1569,7 +1569,7 @@ aside {
  * search-scope.scss
  * Define search scope styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-scope {
   margin: 1.46667em 0; }
@@ -1663,7 +1663,7 @@ aside {
  * pagination.scss
  * Define pagination styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-pager {
   background-color: transparent; }
@@ -1754,7 +1754,7 @@ aside {
  * search-results-stat.scss
  * Define search results statistic styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-results-stat {
   font-size: 0.9em;
@@ -1767,7 +1767,7 @@ aside {
  * applied-filters.scss
  * Define applied filters styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .applied-filters {
   margin: 1.46667em 0;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,6 +30,7 @@
 
 /* Component (SMACSS module) rules */
 @import "components/text-search/search-form";
+@import "components/text-search/autocomplete";
 @import "components/search-filters";
 @import "components/aside";
 @import "components/results/search-results";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,6 +1639,7 @@ class-utils@^0.3.5:
 classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@4.1.x:
   version "4.1.11"
@@ -2330,6 +2331,7 @@ dom-urls@^1.1.0:
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -3230,6 +3232,7 @@ follow-redirects@^1.0.0:
 for-each@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
 
@@ -3487,6 +3490,7 @@ global-prefix@^1.0.1:
 global@~4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  integrity sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
@@ -3710,6 +3714,11 @@ hawk@~6.0.2:
 he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -4070,9 +4079,14 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
+is-callable@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-callable@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
 
 is-ci@^1.0.10:
   version "1.1.0"
@@ -4163,6 +4177,7 @@ is-fullwidth-code-point@^2.0.0:
 is-function@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+  integrity sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -5239,6 +5254,7 @@ mimic-fn@^1.0.0:
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
 
@@ -5852,6 +5868,7 @@ parse-glob@^3.0.4:
 parse-headers@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.1.tgz#6ae83a7aa25a9d9b700acc28698cd1f1ed7e9536"
+  integrity sha1-aug6eqJanZtwCswoaYzR8e1+lTY=
   dependencies:
     for-each "^0.3.2"
     trim "0.0.1"
@@ -6348,6 +6365,7 @@ process@^0.11.10:
 process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+  integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
 
 progress@^2.0.0:
   version "2.0.0"
@@ -7901,6 +7919,7 @@ trim-right@^1.0.1:
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
 
 "true-case-path@^1.0.2":
   version "1.0.2"
@@ -8410,6 +8429,7 @@ xdg-basedir@^3.0.0:
 xhr@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.5.0.tgz#bed8d1676d5ca36108667692b74b316c496e49dd"
+  integrity sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==
   dependencies:
     global "~4.3.0"
     is-function "^1.0.1"
@@ -8427,6 +8447,7 @@ xregexp@^3.2.0:
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 y18n@^3.2.1:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7408,9 +7408,9 @@ sockjs@0.3.18:
     faye-websocket "^0.10.0"
     uuid "^2.0.2"
 
-"solr-faceted-search-react@git+ssh://git@github.com:palantirnet/solr-faceted-search-react#root-138-autocomplete":
+"solr-faceted-search-react@https://github.com/palantirnet/solr-faceted-search-react":
   version "0.12.1"
-  resolved "git+ssh://git@github.com:palantirnet/solr-faceted-search-react#f0df9079a3a0e56d866ff2640c780decc645617a"
+  resolved "https://github.com/palantirnet/solr-faceted-search-react#18f30924d689ffbdd36e7074630cf3bc637abeac"
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2158,12 +2158,19 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
-define-properties@^1.0.1, define-properties@^1.1.2:
+define-properties@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -2471,6 +2478,18 @@ es-abstract@^1.10.0, es-abstract@^1.2.1, es-abstract@^1.4.3, es-abstract@^1.5.1,
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
+es-abstract@^1.5.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
 es-to-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
@@ -2478,6 +2497,15 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.42"
@@ -3229,7 +3257,7 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "^3.1.0"
 
-for-each@^0.3.2:
+for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
@@ -3249,6 +3277,7 @@ for-own@^0.1.4:
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -3339,6 +3368,7 @@ fstream@^1.0.0, fstream@^1.0.2:
 function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 function.prototype.name@^1.1.0:
   version "1.1.0"
@@ -3635,6 +3665,7 @@ has-flag@^3.0.0:
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -3667,15 +3698,10 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
-  dependencies:
-    function-bind "^1.0.2"
-
-has@^1.0.2:
+has@^1.0.1, has@^1.0.2, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
 
@@ -4083,7 +4109,7 @@ is-callable@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
-is-callable@^1.1.3:
+is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
   integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
@@ -4109,6 +4135,7 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -4301,6 +4328,7 @@ is-redirect@^1.0.0:
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
 
@@ -4329,6 +4357,13 @@ is-svg@^2.0.0:
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-touch-device@^1.0.1:
   version "1.0.1"
@@ -5651,9 +5686,14 @@ object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
 
-object-keys@^1.0.11, object-keys@^1.0.8:
+object-keys@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-keys@^1.0.12, object-keys@^1.0.8:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -5866,12 +5906,12 @@ parse-glob@^3.0.4:
     is-glob "^2.0.0"
 
 parse-headers@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.1.tgz#6ae83a7aa25a9d9b700acc28698cd1f1ed7e9536"
-  integrity sha1-aug6eqJanZtwCswoaYzR8e1+lTY=
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.2.tgz#9545e8a4c1ae5eaea7d24992bca890281ed26e34"
+  integrity sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==
   dependencies:
-    for-each "^0.3.2"
-    trim "0.0.1"
+    for-each "^0.3.3"
+    string.prototype.trim "^1.1.2"
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -7368,9 +7408,9 @@ sockjs@0.3.18:
     faye-websocket "^0.10.0"
     uuid "^2.0.2"
 
-"solr-faceted-search-react@https://github.com/palantirnet/solr-faceted-search-react":
+"solr-faceted-search-react@git+ssh://git@github.com:palantirnet/solr-faceted-search-react#root-138-autocomplete":
   version "0.12.1"
-  resolved "https://github.com/palantirnet/solr-faceted-search-react#2df2db3ce3d0bd4781d19179217f53013f4f7c44"
+  resolved "git+ssh://git@github.com:palantirnet/solr-faceted-search-react#82eb9366e0650b43be57565139da296ffc62e565"
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"
@@ -7606,6 +7646,15 @@ string.prototype.padstart@^3.0.0:
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.4.3"
+    function-bind "^1.0.2"
+
+string.prototype.trim@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  integrity sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
     function-bind "^1.0.2"
 
 string.prototype.trimleft@^2.0.0:
@@ -7922,11 +7971,6 @@ trim-repeated@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
 
 "true-case-path@^1.0.2":
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6549,6 +6549,13 @@ react-animate-height@1.0.2:
   optionalDependencies:
     "@types/react" ">=15"
 
+react-aria-live@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-aria-live/-/react-aria-live-2.0.2.tgz#9cfc2352544275586f74b66d18c54a8b3b00398a"
+  integrity sha512-a94NMIidZMX+p+s2+UPTcE+fzl+68RYcdjs4GUDOTe7xV9W0w9fw223Me7E7+PSibwBHrlf6LaJLQBgyi+TbyQ==
+  dependencies:
+    uuid "^3.2.1"
+
 react-autosuggest@9.4.3:
   version "9.4.3"
   resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.4.3.tgz#eb46852422a48144ab9f39fb5470319222f26c7c"
@@ -8153,6 +8160,11 @@ uuid@^2.0.2:
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.2.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,6 +5614,11 @@ object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+  integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
+
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -6526,6 +6531,24 @@ react-animate-height@1.0.2:
   optionalDependencies:
     "@types/react" ">=15"
 
+react-autosuggest@9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.4.3.tgz#eb46852422a48144ab9f39fb5470319222f26c7c"
+  integrity sha512-wFbp5QpgFQRfw9cwKvcgLR8theikOUkv8PFsuLYqI2PUgVlx186Cz8MYt5bLxculi+jxGGUUVt+h0esaBZZouw==
+  dependencies:
+    prop-types "^15.5.10"
+    react-autowhatever "^10.1.2"
+    shallow-equal "^1.0.0"
+
+react-autowhatever@^10.1.2:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.2.0.tgz#bdd07bf19ddf78acdb8ce7ae162ac13b646874ab"
+  integrity sha512-dqHH4uqiJldPMbL8hl/i2HV4E8FMTDEdVlOIbRqYnJi0kTpWseF9fJslk/KS9pGDnm80JkYzVI+nzFjnOG/u+g==
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
 react-dates@16.4.0:
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react-dates/-/react-dates-16.4.0.tgz#61dee21082758e14d89103974be769b653f33c45"
@@ -6590,6 +6613,13 @@ react-portal@^4.1.2:
   resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.1.5.tgz#6665d4d2a92d47d6f8b07a6529e26fc52d5cccde"
   dependencies:
     prop-types "^15.5.8"
+
+react-themeable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
+  integrity sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=
+  dependencies:
+    object-assign "^3.0.0"
 
 react-with-direction@1.3.0, react-with-direction@^1.1.0:
   version "1.3.0"
@@ -7093,6 +7123,11 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+section-iterator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
+  integrity sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -7204,6 +7239,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.1.0.tgz#cc022f030dcba0d1c198abf658a3c6c744e171ca"
+  integrity sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw==
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This PR adds the option of enabling a configuring the main query text field to implement search as you type functionality, taking advantage of new functionality built in https://github.com/palantirnet/solr-faceted-search-react/pull/7

## To test

### Get a local instance of the federated search demo up and running
1. Check out master in the [Drupal federated-search-demo](https://github.com/palantirnet/federated-search-demo) project
1. Boot the vm `vagrant up`, ssh in to the vm `vagrant ssh` and [build the sites](https://github.com/palantirnet/federated-search-demo#rebuild-all-the-things) with `phing build-all init`
1. Log in to the standalone d8 site `drush @fsd-d8.local uli`
1. Clear + reindex all items in the index at: http://d8.fs-demo.local/admin/config/search/search-api/index/federated_search_index
1. Note: we'll be using the index provided by the demo site, but won't yet be using the search page on the demo site

### Get your local app environment set up
1. Pull this branch down
1. Update [the version of the search app dependency](https://github.com/palantirnet/solr-faceted-search-react/pull/7) and install some new dependencies with `yarn install`

### Verify when no autocomplete configuration present, the app functions as it used to, with a standard text search functionality
1. Start the app with `yarn start`
1. The search app should load in a new browser window
1. Observe you can still search and use the facets/filters

### Add new autocomplete config
1. Observe updates to the `src/env.local.js.example` file
1. Add configuration for your solr backend and autocomplete to your `src/env.local.js`, here is what mine looks like:

```js
module.exports = {
  // REQUIRED: The default solr backend.
  // url: "https://ss826806-us-east-1-aws.measuredsearch.com:443/solr/master/select",
  url: "http://federated-search-demo.local:8983/solr/drupal8/select",
  // OPTIONAL: The default "Site Name" facet value.
  // Note: This value must match the "site_name" property for one of your sites.
  // siteSearch: 'U of M Lab Blog',
  // userpass: btoa("palantir:palantirqauser"),
  // OPTIONAL: The text to display when a search returns no results.
  // noResults: "Sorry, your search yielded no results.",
  // OPTIONAL: The text to display when the app loads with no search term.
  searchPrompt: "Please enter a search term.",
  // OPTIONAL: The number of search results to show per page.
  rows: 20,
  // OPTIONAL: The number of page buttons to show for pagination.
  paginationButtons: 5,
  // OPTIONAL: Provides config for adding autocomplete functionality to text search
  autocomplete: {
    mode: 'result',
    url: 'http://federated-search-demo.local:8983/solr/drupal8/select',
    queryField: 'tem_suggestion_title',
    suggestionRows: 5,
	numChars: 2,
    result: {
      titleText: 'What are you interested in?',
      directionsText: true,
    },
  }
};
```

### Test basic autocomplete functionality
1. Upon saving your `src/env.local.js` file, observe the app reloads and that the text search input looks identical
1. Begin typing search queries and observe that after the 2nd character (or whatever value you used for `autocomplete.numChars` in your `src/env.local.js` file) the search as you type suggestion results render.
1. Observe that as you continue to type, the results get refined.
1. Observe that, when the the suggestions render:
    1. there are instructions for sighted keyboard users
    1. there is a close button to clear suggestions

### Test that facet / filter values are honored in suggestion query
1. Search for "uma"
1. Observe the suggestions (and observe Uma and uma are highlighted in suggestion text)
1. Expand the `Type` filter accordion
1. Select `Page`
1. Bring focus to the search input by clicking inside of it
1. Observe the suggestions now reflect the `Type=Page` filter

## Next steps
- ~remove any default field that is currently sent in the query~
- ~ensure that query parsers, fields (including defaults and boosts) can be configured in solr config~
- ~add the ability to hide any facet / filter group from app config~
- update the module app config to pass in:
	- autocomplete
	- hidden facet/filter groups
	- more default values?