### PR TITLE
Root 198 enable ui hide facets filters

### DIFF
--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -41,6 +41,14 @@ module.exports = {
   pageTitle: null,
   // OPTIONAL: The hostname to emulate when testing.
   hostname: "example.local",
+  // OPTIONAL: Machine name of those search fields whose facets/filter and current values should be hidden in UI.
+  // Note: if their values are pre-set (i.e. sent in qs to app), they will still be sent in the query.
+  // hiddenSearchFields: [ // Defaults to [];
+  //   'sm_site_name',
+  //   'ss_federated_type',
+  //   'ds_federated_date',
+  //   'sm_federated_terms',
+  // ],
   // OPTIONAL: Provides config for adding autocomplete functionality to text search
   // autocomplete : {
   //   url: <your-endpoint-for-autocomplete-results>, // required @todo document accepted types

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -24,9 +24,6 @@ module.exports = {
   // OPTIONAL: If the solr backend requires Basic Authentication, uncomment below and enter the username and password
   // in the btoa function as specified below. This should ONLY allow READ access, as it will be accessible client-side.
   // userpass: btoa("username:password"),
-  // OPTIONAL: The default "Site Name" facet value.
-  // Note: This value must match the "site_name" property for one of your sites.
-  siteSearch: null,
   // OPTIONAL: The text to display when a search returns no results.
   noResults: "Sorry, your search yielded no results.",
   // OPTIONAL: Whether or not to display all results on empty search.

--- a/src/components/current-query/index.js
+++ b/src/components/current-query/index.js
@@ -165,7 +165,8 @@ class FederatedCurrentQuery extends React.Component {
                 <p className="element-invisible">
                   Click a filter to remove it from your search query.
                 </p>
-                {fields.map((searchField, i) => {
+                {/* Only render the values for visible facets / filters */}
+                {fields.filter(searchField => !searchField.isHidden).map((searchField, i) => {
                   // Determine which child component to render.
                   const MyFacetType = facetTypes[searchField.type];
                   return (

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -82,8 +82,11 @@ class FederatedSolrFacetedSearch extends React.Component {
               onNewSearch={this.resetFilters.bind(this)}
               resultsCount={this.props.results.numFound}
             >
+              {/* Only render the visible facets / filters.
+                  Note: their values may still be used in the query, if they were pre-set. */}
               {searchFields
-                .filter(searchField => this.props.sidebarFilters.indexOf(searchField.field) > -1)
+                .filter(searchField => this.props.sidebarFilters.indexOf(searchField.field) > -1
+                  && !searchField.isHidden)
                 .map((searchField, i) => {
                   const {
                     type,

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -33,7 +33,9 @@ class FederatedTextSearchAsYouType extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      value: nextProps.suggestQuery ? nextProps.suggestQuery.value : nextProps.value,
+      value: nextProps.suggestQuery && nextProps.suggestQuery.value
+        ? nextProps.suggestQuery.value
+        : nextProps.value,
       suggestions: nextProps.suggestions ? nextProps.suggestions.docs : this.state.suggestions,
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,16 @@ const init = (settings) => {
 
   const options = Object.assign(defaults, settings);
 
+  // Update searchFields to indicate which facets or filters should be hidden in the UI.
+  // Note: these facets and filters may still be used in the query.
+  settings.hiddenSearchFields = settings.hiddenSearchFields || [];
+  options.searchFields = options.searchFields.map(searchField => {
+    if (settings.hiddenSearchFields.includes(searchField.field)) {
+      searchField.isHidden = true;
+    }
+    return searchField;
+  });
+
   // The client class
   const solrClient = new SolrClient({
     url: options.url,

--- a/src/index.js
+++ b/src/index.js
@@ -85,11 +85,11 @@ const init = (settings) => {
     url: "",
     // The search fields and filterable facets.
     searchFields: [
-      {label: "Enter Search Term:", field: "tm_rendered_item", type: "text"},
-      {label: "Site Name", field: "sm_site_name", type: "list-facet", collapse: true},
-      {label: "Type", field: "ss_federated_type", type: "list-facet", collapse: true},
-      {label: "Date", field: "ds_federated_date", type: "range-facet", collapse: true},
-      {label: "Federated Terms", field: "sm_federated_terms", type: "list-facet", hierarchy: true},
+      {label: "Enter Search Term:", field: "tm_rendered_item", type: "text", isHidden: false},
+      {label: "Site Name", field: "sm_site_name", type: "list-facet", collapse: true, isHidden: false},
+      {label: "Type", field: "ss_federated_type", type: "list-facet", collapse: true, isHidden: false},
+      {label: "Date", field: "ds_federated_date", type: "range-facet", collapse: true, isHidden: false},
+      {label: "Federated Terms", field: "sm_federated_terms", type: "list-facet", hierarchy: true, isHidden: false},
     ],
     // The solr field to use as the source for the main query param "q".
     mainQueryField: "tm_rendered_item",


### PR DESCRIPTION
This PR adds functionality that will enable `search_api_federated_solr` implementers to select filter/facet fields that they'd like to be hidden in the UI.  

Note that this functionality does not preclude those fields from being pre-set and sent in the query (however, at this point only the site name can be set and sent in this way as of now).

## To test

### Get a local instance of the federated search demo up and running
1. Check out master in the [Drupal federated-search-demo](https://github.com/palantirnet/federated-search-demo) project
1. Boot the vm `vagrant up`, ssh in to the vm `vagrant ssh` and [build the sites](https://github.com/palantirnet/federated-search-demo#rebuild-all-the-things) with `phing build install-all init`
1. Log in to the standalone d8 site `drush @fsd-d8.local uli`
1. Clear + reindex all items in the index at: http://d8.fs-demo.local/admin/config/search/search-api/index/federated_search_index
1. Note: we'll be using the index provided by the demo site, but won't yet be using the search page on the demo site

### Get your local app environment set up
1. Pull this branch down
1. Update [the version of the search app dependency](https://github.com/palantirnet/solr-faceted-search-react/pull/7) with `yarn install`

### Verify that when no `hiddenSearchFields` configuration present, the app functions as it should with all facets/filters visible
1. Start the app with `yarn start`
1. The search app should load in a new browser window
1. Observe you can still search and use the facets/filters

### Confirm searchFields values can still be preset via qs params for main text search field and for site search field
1. Use the following URL to prepopulate the site search name facet and main text search field for your search app: http://localhost:3000/?search=pasta&sm_site_name=Federated%20Search%20Demo%20%28D8%2C%20single%29
1. Observe the site name sidebar filter checkbox for the D8 demo site is checked
1. Observe the current query area has the follow active filter tags: your search term, the current site name

### Add new `hiddenSearchFields` config
1. Observe [updates to the `src/env.local.js.example` file](https://github.com/palantirnet/federated-search-react/compare/root-198-autocomplete-component...root-198-enable-ui-hide-facets-filters?expand=1#diff-031d69d5bd943ba033e405d36ad584f3)
1. Add configuration to hide the site name and type search fields in the UI for the sidebar facets/filters and the current query area, here is what mine looks like:

```js
module.exports = {
  // REQUIRED: The default solr backend.
  // url: "https://ss826806-us-east-1-aws.measuredsearch.com:443/solr/master/select",
  url: "http://federated-search-demo.local:8983/solr/drupal8/select",
  // userpass: btoa("palantir:palantirqauser"),
  // OPTIONAL: The text to display when a search returns no results.
  // noResults: "Sorry, your search yielded no results.",
  // OPTIONAL: The text to display when the app loads with no search term.
  searchPrompt: "Please enter a search term.",
  // OPTIONAL: The number of search results to show per page.
  rows: 20,
  // OPTIONAL: The number of page buttons to show for pagination.
  paginationButtons: 5,
  // OPTIONAL: Machine name of those search fields whose facets/filter and current values should be hidden in UI.
  hiddenSearchFields: [
    'sm_site_name',
    'ss_federated_type',
    // 'ds_federated_date',
    // 'sm_federated_terms',
  ],
  // OPTIONAL: Provides config for adding autocomplete functionality to text search
  autocomplete: {
    url: 'http://federated-search-demo.local:8983/solr/drupal8/select',
    queryField: 'tem_suggestion_title',
    suggestionRows: 5,
    numChars: 2,
    mode: 'result',
    result: {
      titleText: 'What are you interested in?',
      showDirectionsText: true,
    },
  }
};

```

### Observe search fields are hidden from sidebar and current query in UI
1. Upon saving your `src/env.local.js` file, observe the app reloads and the filters you have included in the `hiddenSearchFields` array have been removed from the sidebar filters
1. Observe that where you once saw the site name active filter tag under the main text search field, you now only see the search term active tag

### Confirm your site name filter value is still sent along with the query even though it is hidden from the UI
1. Assuming your browser URL for the app still includes the site name param: `&sm_site_name=Federated%20Search%20Demo%20%28D8%2C%20single%29`
1. Open your browser devTools (`COMMAND + alt + i`) for chrome / firefox
1. Click the Network tab of your devtools
1. Ensure that you aren't filtering any network requests by type, or at least ensure XHR is included in your filter
    - Chrome:
        ![image](https://user-images.githubusercontent.com/3279883/53520830-93c94700-3aa4-11e9-9200-fc4307de11d0.png)
    - Firefox:
        ![image](https://user-images.githubusercontent.com/3279883/53520891-c115f500-3aa4-11e9-9580-d1fb621a23c2.png)
1. Refresh the page to start logging network traffic
1. Find the request for the search execution and browse the headers or params and verify you can still see `sm_site_name` facet + value sent as a `fq` param in the request
    - Chrome:		
        ![image](https://user-images.githubusercontent.com/3279883/53520797-7b592c80-3aa4-11e9-8e64-8c5ef2eb4ce4.png)
    - Firefox:
        ![image](https://user-images.githubusercontent.com/3279883/53520866-b0657f00-3aa4-11e9-869a-6b1fe4cbe993.png)

### Test other combinations 

Play around with different combinations of hidden search fields.  Note: I haven't implemented logic to hide the main text field, but we could?!


## TODO
- [ ] Add logic that checks if all sidebar filters are hidden and if so, hides the entire sidebar
- [ ] Write `hiddenSearchFields` config options + output in `search_api_federated_solr`

## Open question
1. As of now, the only field/filter/facet values that persist in the URL as qs params (and thus the only ones which can be preset and honored in the query even when hidden from the UI) are the main search term, site name, and type.  Should I work on supporting date + term filter values in the qs and exposing all filters as pre-setable in the search app?