### PR TITLE
Root 198 track term facets in qs

### DIFF
--- a/src/components/current-query/index.js
+++ b/src/components/current-query/index.js
@@ -32,7 +32,9 @@ class ListFacetType extends React.Component {
       value,
     });
 
+    // Confirm the field value is set in state.
     if (foundIdx > -1) {
+      // If the field is one whose state is tracked in qs and there is currently a param for it.
       if (isQsParamField && param) {
         const newParsed = helpers.qs.removeValueFromQsParam({
           field,

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { LiveAnnouncer } from 'react-aria-live';
 import FederatedSolrComponentPack from './federated_solr_component_pack';
+import helpers from '../helpers';
 //import componentPack from "./component-pack";
 
 const getFacetValues = (type, results, field, lowerBound, upperBound) => {
@@ -21,12 +22,30 @@ class FederatedSolrFacetedSearch extends React.Component {
 
   resetFilters() {
     let { query } = this.props;
+    let searchTerm = '';
     // Keep only the value of the main search field.
     for (const field of query.searchFields) {
       if (field.field !== query.mainQueryField) {
-        delete(field.value);
+        // Remove the field value.
+        delete (field.value);
+        // Collapse the sidebar filter toggle.
+        field.collapse = true;
+        // Collapse the terms sidebar filter toggle.
+        if (Object.hasOwnProperty.call(field, 'expandedHierarchies')) {
+          field.expandedHierarchies = [];
+        }
+      } else {
+        // Extract the value of the main search term to use when setting new URL for this state.
+        searchTerm = field.value;
       }
     }
+    // Set new parsed params based on only search term value.
+    const parsed = {
+      search: searchTerm,
+    };
+    // Add new url to browser window history.
+    helpers.qs.addNewUrlToBrowserHistory(parsed);
+
     // Update state to remove the filter field values.
     this.setState({ query });
     // Execute search.

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -13,16 +13,22 @@ const getFacetValues = (type, results, field, lowerBound, upperBound) => {
 };
 
 class FederatedSolrFacetedSearch extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.resetFilters = this.resetFilters.bind(this);
+  }
+
   resetFilters() {
-    let {query} = this.props;
+    let { query } = this.props;
     // Keep only the value of the main search field.
-    for (let field of query.searchFields) {
+    for (const field of query.searchFields) {
       if (field.field !== query.mainQueryField) {
         delete(field.value);
       }
     }
     // Update state to remove the filter field values.
-    this.setState({query});
+    this.setState({ query });
     // Execute search.
     this.props.onSearchFieldChange();
   }
@@ -79,7 +85,7 @@ class FederatedSolrFacetedSearch extends React.Component {
           <aside className="l-25-75--1">
             <SearchFieldContainerComponent
               bootstrapCss={bootstrapCss}
-              onNewSearch={this.resetFilters.bind(this)}
+              onNewSearch={this.resetFilters}
               resultsCount={this.props.results.numFound}
             >
               {/* Only render the visible facets / filters.

--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -28,39 +28,44 @@ class FederatedListFacet extends React.Component {
       value,
     });
 
-    // console.log(foundIdx, parsed, isQsParamField, param);
-
     // Define var for new parsed qs params object.
     let newParsed = parsed;
 
-    if (foundIdx < 0) {
-      if (isQsParamField && param) {
-        // Add value to parsed qs params.
-        newParsed = helpers.qs.addValueToQsParam({
-          field: this.props.field,
-          value,
-          param,
-          parsed,
-        });
-      }
-
-      // Send new query based on app state.
-      this.props.onChange(this.props.field, this.props.value.concat(value));
-    } else {
-      if (isQsParamField && param) {
-        newParsed = helpers.qs.removeValueFromQsParam({
-          field: this.props.field,
-          value,
-          param,
-          parsed,
-        });
-      }
-
-      // Send new query based on app state.
-      this.props.onChange(this.props.field, this.props.value.filter((v, i) => i !== foundIdx));
-    }
-
     if (isQsParamField) {
+      if (foundIdx < 0) {
+        if (param) {
+          // Add value to parsed qs params.
+          newParsed = helpers.qs.addValueToQsParam({
+            field: this.props.field,
+            value,
+            param,
+            parsed,
+          });
+        } else {
+          // Add new qs param for field + value.
+          newParsed = helpers.qs.addQsParam({
+            field: this.props.field,
+            value,
+            parsed,
+          });
+        }
+
+        // Send new query based on app state.
+        this.props.onChange(this.props.field, this.props.value.concat(value));
+      } else {
+        if (param) {
+          newParsed = helpers.qs.removeValueFromQsParam({
+            field: this.props.field,
+            value,
+            param,
+            parsed,
+          });
+        }
+
+        // Send new query based on app state.
+        this.props.onChange(this.props.field, this.props.value.filter((v, i) => i !== foundIdx));
+      }
+
       helpers.qs.addNewUrlToBrowserHistory(newParsed);
     }
   }

--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -19,7 +19,8 @@ class FederatedListFacet extends React.Component {
   handleClick(value) {
     const foundIdx = this.props.value.indexOf(value);
     // Get existing querystring params.
-    const parsed = queryString.parse(window.location.search);
+    const parsed = queryString.parse(window.location.search, { arrayFormat: 'bracket' });
+    const params = Object.entries(parsed);
 
     // Those filter fields for which we want to preserve state in qs.
     // @todo handle parsing of terms and dates
@@ -27,22 +28,43 @@ class FederatedListFacet extends React.Component {
     const filterFieldsWithQsState = [
       'sm_site_name',
       'ss_federated_type',
+      'sm_federated_terms',
     ];
 
-    const isQsParamField = filterFieldsWithQsState.find((item) => item === this.props.field);
+    const isQsParamField = filterFieldsWithQsState.find(item => item === this.props.field);
+    const param = params.find(item => item[0] === this.props.field);
 
     if (foundIdx < 0) {
       // Add a param for this field to the parsed qs object.
-      if (isQsParamField) {
-        parsed[this.props.field] = value;
+      if (isQsParamField && param) {
+        // Handle single value params.
+        if (typeof param[1] !== 'object' && value !== param[1]) {
+          // Add the param for this field from the parsed qs object.
+          parsed[this.props.field] = value;
+        }
+        // Handle multi value params.
+        if (typeof param[1] === 'object' && !param[1].includes(value)) {
+          // Add the list item facet value to the param value.
+          param[1].push(value);
+          // Set the new param value.
+          parsed[this.props.field] = [...param[1]];
+        }
       }
 
       // Send new query based on app state.
       this.props.onChange(this.props.field, this.props.value.concat(value));
     } else {
-      if (isQsParamField) {
-        // Remove the param for this field from the parsed qs object.
-        delete parsed[this.props.field];
+      if (isQsParamField && param) {
+        // Handle single value params.
+        if (typeof param[1] !== 'object' && value === param[1]) {
+          // Remove the param for this field from the parsed qs object.
+          delete parsed[this.props.field];
+        }
+        // Handle multi value params.
+        if (typeof param[1] === 'object' && param[1].includes(value)) {
+          // Remove the list facet value from the param.
+          parsed[this.props.field] = param[1].filter(item => item !== value);
+        }
       }
 
       // Send new query based on app state.
@@ -51,7 +73,7 @@ class FederatedListFacet extends React.Component {
 
     if (isQsParamField) {
       // Update the search querystring param with the value from the search field.
-      const stringified = queryString.stringify(parsed);
+      const stringified = queryString.stringify(parsed, { arrayFormat: 'bracket' });
       // Update the querystring params in the browser, add path to history.
       // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
       if (window.history.pushState) {

--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -31,8 +31,11 @@ class FederatedListFacet extends React.Component {
     // Define var for new parsed qs params object.
     let newParsed = parsed;
 
+    // If the clicked list facet field is one whose state is tracked in the qs.
     if (isQsParamField) {
+      // If the click is adding the field value.
       if (foundIdx < 0) {
+        // If there is already a qs param for this field value.
         if (param) {
           // Add value to parsed qs params.
           newParsed = helpers.qs.addValueToQsParam({
@@ -41,7 +44,7 @@ class FederatedListFacet extends React.Component {
             param,
             parsed,
           });
-        } else {
+        } else { // If there is not already a qs param for this field value.
           // Add new qs param for field + value.
           newParsed = helpers.qs.addQsParam({
             field: this.props.field,
@@ -52,7 +55,8 @@ class FederatedListFacet extends React.Component {
 
         // Send new query based on app state.
         this.props.onChange(this.props.field, this.props.value.concat(value));
-      } else {
+      } else { // If the click is removing this field value.
+        // If their is already a qs param for this field value.
         if (param) {
           newParsed = helpers.qs.removeValueFromQsParam({
             field: this.props.field,

--- a/src/components/search-field-container.js
+++ b/src/components/search-field-container.js
@@ -1,11 +1,10 @@
 import PropTypes from 'prop-types';
-import React from "react";
-import cx from "classnames";
+import React from 'react';
+import cx from 'classnames';
 import AnimateHeight from 'react-animate-height';
 
 
 class FederatedSearchFieldContainer extends React.Component {
-
   constructor(props) {
     super(props);
 
@@ -14,14 +13,16 @@ class FederatedSearchFieldContainer extends React.Component {
 
     this.state = {
       // Filters are visible for large / hidden for small screens by default.
-      expanded: intFrameWidth > 900
+      expanded: intFrameWidth > 900,
     };
+
+    this.handleClick = this.handleClick.bind(this);
   }
 
   handleClick() {
     this.setState({
-      expanded: !this.state.expanded
-    })
+      expanded: !this.state.expanded,
+    });
   }
 
   render() {
@@ -30,10 +31,17 @@ class FederatedSearchFieldContainer extends React.Component {
 
     return (
       <div className="search-filters">
-        <button className={cx("search-filters__trigger", {"js-search-filters-open": this.state.expanded})} onClick={this.handleClick.bind(this)}>Filter Results</button>
+        <button
+          className={cx('search-filters__trigger', {
+            'js-search-filters-open': this.state.expanded,
+          })}
+          onClick={this.handleClick}
+        >
+            Filter Results
+        </button>
         <AnimateHeight
-            duration={450}
-            height={height}
+          duration={450}
+          height={height}
         >
           <form className="search-filters__form">
             <section className="search-accordion" aria-labelledby="section-title">
@@ -57,7 +65,7 @@ class FederatedSearchFieldContainer extends React.Component {
 
 FederatedSearchFieldContainer.propTypes = {
   children: PropTypes.array,
-  onNewSearch: PropTypes.func
+  onNewSearch: PropTypes.func,
 };
 
 export default FederatedSearchFieldContainer;

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import queryString from 'query-string';
 
 /**
  * Find and highlight relevant keywords within a block of text
@@ -22,6 +23,134 @@ const highlightText = (text, highlight) => {
     </span>);
 };
 
+// Those filter fields for which we want to preserve state in qs.
+const filterFieldsWithQsState = [
+  'sm_site_name',
+  'ss_federated_type',
+  'sm_federated_terms',
+];
+
+const qs = {
+  // Get the qs params, break into array of [key,value] pairs.
+  // Params with multiple values (i.e. federated terms) use the following syntax:
+  // ...&sm_federated_terms[]=value1&sm_federated_terms[]=value2
+  getParsedQsAndParams: () => {
+    const parsed = queryString.parse(window.location.search, { arrayFormat: 'bracket' });
+    return {
+      parsed,
+      params: Object.entries(parsed),
+    };
+  },
+  getFieldQsInfo: ({ field, values, value }) => {
+    const foundIdx = values.indexOf(value);
+    // Get existing querystring params.
+    const { parsed, params } = qs.getParsedQsAndParams();
+    console.log(parsed, params);
+
+    // Check if the search field is one for which we preserve state through qs.
+    const isQsParamField = filterFieldsWithQsState.find(item => item === field);
+    console.log(isQsParamField);
+
+    // Check if the filter field exists in qs param.
+    const param = params.find(item => item[0] === field);
+    console.log(param);
+
+    return {
+      foundIdx,
+      parsed,
+      isQsParamField,
+      param,
+    };
+  },
+  addValueToQsParam: ({
+    field,
+    value,
+    param,
+    parsed,
+  }) => {
+    const newParsed = parsed;
+    // Handle single value params.
+    if (typeof param[1] !== 'object' && value !== param[1]) {
+      // Add the param for this field from the parsed qs object.
+      newParsed[field] = value;
+    }
+    // Handle multi value params.
+    if (typeof param[1] === 'object' && !param[1].includes(value)) {
+      // Add the list item facet value to the param value.
+      param[1].push(value);
+      // Set the new param value.
+      newParsed[field] = [...param[1]];
+    }
+    return newParsed;
+  },
+  removeValueFromQsParam: ({
+    field,
+    value,
+    param,
+    parsed,
+  }) => {
+    const newParsed = parsed;
+    // Remove value from parsed qs params.
+    // Handle single value params.
+    if (typeof param[1] !== 'object' && value === param[1]) {
+      // Remove the param for this field from the parsed qs object.
+      delete newParsed[field];
+    }
+    // Handle multi value params.
+    if (typeof param[1] === 'object' && param[1].includes(value)) {
+      // Remove the list facet value from the param.
+      newParsed[field] = param[1].filter(item => item !== value);
+    }
+
+    return newParsed;
+  },
+  addNewUrlToBrowserHistory: (parsed) => {
+    // Update the search querystring param with the value from the search field.
+    const stringified = queryString.stringify(parsed, { arrayFormat: 'bracket' });
+    // Update the querystring params in the browser, add path to history.
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
+    if (window.history.pushState) {
+      const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+      window.history.pushState({ path: newurl }, '', newurl);
+    } else {
+      window.location.search = stringified;
+    }
+  },
+  setFieldStateFromQs: ({
+    params,
+    searchField,
+  }) => {
+    // Make a copy of the searchField arg.
+    const newSearchField = searchField;
+    // Check if the filter field exists in qs params.
+    const param = params.find((item) => item[0] === searchField.field);
+    // If searchField has corresponding qs param present.
+    if (param) {
+      // Ensure we can push to searchField value.
+      newSearchField.value = searchField.value || [];
+      // Don't add qs param values if they're already set in app state.
+      // Push single values onto the searchField.value array.
+      if (typeof param[1] !== 'object' && !searchField.value.find(item => item === param[1])) {
+        newSearchField.value.push(decodeURI(param[1]));
+      }
+      // Concatenate existing searchField.value array with multivalue param array..
+      if (typeof param[1] === 'object' && searchField.value !== param[1]) {
+        // Decode param values.
+        const decodedParam = param[1].map(item => decodeURI(item));
+        // Set the searchField.value to the new decoded param values.
+        newSearchField.value = [...decodedParam];
+      }
+    } else {
+      // If the searchField does not have qs param present, clear its value in state.
+      delete newSearchField.value;
+    }
+
+    return newSearchField;
+  },
+};
+
 export default {
   highlightText,
+  filterFieldsWithQsState,
+  qs,
 };

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -138,7 +138,7 @@ const qs = {
   }) => {
     const newParsed = parsed;
     const fieldType = field.split('_')[0];
-    const isMultiple = fieldType.charAt(fieldType.length - 1);
+    const isMultiple = fieldType.charAt(fieldType.length - 1) === 'm';
 
     // Handle single value params.
     if (!isMultiple) {
@@ -150,6 +150,7 @@ const qs = {
       // Set the new param value.
       newParsed[field] = [value];
     }
+    console.log(newParsed);
     return newParsed;
   },
   /**

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -31,9 +31,13 @@ const filterFieldsWithQsState = [
 ];
 
 const qs = {
-  // Get the qs params, break into array of [key,value] pairs.
-  // Params with multiple values (i.e. federated terms) use the following syntax:
-  // ...&sm_federated_terms[]=value1&sm_federated_terms[]=value2
+  /**
+   * Gets the qs params as an object and broken into array of [key,value] pairs.
+   * Params with multiple values (i.e. federated terms) use the following syntax:
+   * ...&sm_federated_terms[]=value1&sm_federated_terms[]=value2
+   *
+   * @returns {{parsed: (*|*|*), params: [string, any][]}}
+   */
   getParsedQsAndParams: () => {
     const parsed = queryString.parse(window.location.search, { arrayFormat: 'bracket' });
     return {
@@ -41,7 +45,25 @@ const qs = {
       params: Object.entries(parsed),
     };
   },
+  /**
+   * Determines information related this search field, its value, and state.
+   *
+   * @param field
+   *   this.props.query.searchField.field (i.e. the solr field name)
+   * @param values
+   *   this.props.query.searchField.value (i.e. the current value for the field)
+   * @param value
+   *   The value of the field with which interaction has happened.
+   * @returns object
+   *   An object with:
+   *     foundIdx: the position of the field value in question found in this field's state,
+   *     parsed: an object with parsed qs params and their values,
+   *     isQsParamField: whether or not the field in question should track state in the qs,
+   *     param: an object with the as param and value for this field, if it exists
+   */
   getFieldQsInfo: ({ field, values, value }) => {
+    // Determine if the field value in question exists in this search field's state.
+    // i.e. was it toggled on or off?
     const foundIdx = values.indexOf(value);
     // Get existing querystring params.
     const { parsed, params } = qs.getParsedQsAndParams();
@@ -59,6 +81,20 @@ const qs = {
       param,
     };
   },
+  /**
+   * Updates the parsed object by adding the field value in question to its param key.
+   *
+   * @param field
+   *   this.props.query.searchField.field (i.e. the solr field name)
+   * @param value
+   *   The value of the field with which interaction has happened.
+   * @param param
+   *   An object with the as param and value for this field, if it exists.
+   * @param parsed
+   *   An object with parsed qs params and their values.
+   * @returns Object
+   *   An updated parsed object with the field value in question added.
+   */
   addValueToQsParam: ({
     field,
     value,
@@ -80,6 +116,21 @@ const qs = {
     }
     return newParsed;
   },
+  /**
+   * Updates the parsed object by adding the field and its value to the
+   *   current object of params and their values.
+   *
+   * @param field
+   *   this.props.query.searchField.field (i.e. the solr field name)
+   * @param value
+   *   The value of the field with which interaction has happened.
+   * @param param
+   *   An object with the as param and value for this field, if it exists.
+   * @param parsed
+   *   An object with parsed qs params and their values.
+   * @returns Object
+   *   An updated parsed object with the field + value added.
+   */
   addQsParam: ({
     field,
     value,
@@ -101,6 +152,20 @@ const qs = {
     }
     return newParsed;
   },
+  /**
+   * Updates the parsed object by removing the field value in question to its param key.
+   *
+   * @param field
+   *   this.props.query.searchField.field (i.e. the solr field name)
+   * @param value
+   *   The value of the field with which interaction has happened.
+   * @param param
+   *   An object with the as param and value for this field, if it exists.
+   * @param parsed
+   *   An object with parsed qs params and their values.
+   * @returns Object
+   *   An updated parsed object with the field value in question removed.
+   */
   removeValueFromQsParam: ({
     field,
     value,
@@ -122,6 +187,12 @@ const qs = {
 
     return newParsed;
   },
+  /**
+   * Updates the browser window.history with an entry based on the new parsed qs params and values.
+   *
+   * @param parsed
+   *   An object with parsed qs params and their values.
+   */
   addNewUrlToBrowserHistory: (parsed) => {
     // Update the search querystring param with the value from the search field.
     const stringified = queryString.stringify(parsed, { arrayFormat: 'bracket' });
@@ -134,6 +205,17 @@ const qs = {
       window.location.search = stringified;
     }
   },
+  /**
+   * Sets query.searchFields state based on the state of the qs.
+   * Allows searches to be executed on app load based on URL.
+   *
+   * @param params
+   *   QS params broken into array of [key,value] pairs.
+   * @param searchField
+   *   Search field in question. (this.props.query.searchField)
+   * @returns Object
+   *   Updated this.props.query.searchField based on qs param values.
+   */
   setFieldStateFromQs: ({
     params,
     searchField,
@@ -141,7 +223,7 @@ const qs = {
     // Make a copy of the searchField arg.
     const newSearchField = searchField;
     // Check if the filter field exists in qs params.
-    const param = params.find((item) => item[0] === searchField.field);
+    const param = params.find(item => item[0] === searchField.field);
     // If searchField has corresponding qs param present.
     if (param) {
       // Ensure we can push to searchField value.

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -86,13 +86,16 @@ const qs = {
     parsed,
   }) => {
     const newParsed = parsed;
+    const fieldType = field.split('_')[0];
+    const isMultiple = fieldType.charAt(fieldType.length - 1);
+
     // Handle single value params.
-    if (typeof value !== 'object') {
+    if (!isMultiple) {
       // Add the param for this field from the parsed qs object.
       newParsed[field] = value;
     }
     // Handle multi value params.
-    if (typeof value === 'object') {
+    if (isMultiple) {
       // Set the new param value.
       newParsed[field] = [value];
     }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -45,15 +45,12 @@ const qs = {
     const foundIdx = values.indexOf(value);
     // Get existing querystring params.
     const { parsed, params } = qs.getParsedQsAndParams();
-    console.log(parsed, params);
 
     // Check if the search field is one for which we preserve state through qs.
     const isQsParamField = filterFieldsWithQsState.find(item => item === field);
-    console.log(isQsParamField);
 
     // Check if the filter field exists in qs param.
     const param = params.find(item => item[0] === field);
-    console.log(param);
 
     return {
       foundIdx,
@@ -80,6 +77,24 @@ const qs = {
       param[1].push(value);
       // Set the new param value.
       newParsed[field] = [...param[1]];
+    }
+    return newParsed;
+  },
+  addQsParam: ({
+    field,
+    value,
+    parsed,
+  }) => {
+    const newParsed = parsed;
+    // Handle single value params.
+    if (typeof value !== 'object') {
+      // Add the param for this field from the parsed qs object.
+      newParsed[field] = value;
+    }
+    // Handle multi value params.
+    if (typeof value === 'object') {
+      // Set the new param value.
+      newParsed[field] = [value];
     }
     return newParsed;
   },

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ const init = (settings) => {
       {label: "Site Name", field: "sm_site_name", type: "list-facet", collapse: true, isHidden: false},
       {label: "Type", field: "ss_federated_type", type: "list-facet", collapse: true, isHidden: false},
       {label: "Date", field: "ds_federated_date", type: "range-facet", collapse: true, isHidden: false},
-      {label: "Federated Terms", field: "sm_federated_terms", type: "list-facet", hierarchy: true, isHidden: false},
+      {label: "Federated Terms", field: "sm_federated_terms", type: "list-facet", hierarchy: true, expandedHierarchies: [], isHidden: false},
     ],
     // The solr field to use as the source for the main query param "q".
     mainQueryField: "tm_rendered_item",


### PR DESCRIPTION
## Description

This PR adds functionality to the search app which tracks the state of federated term facets in the qs:

- on app load the state of the federated terms search field will be set based on any terms passed in via the url qs with the following syntax: `federated_terms[]=group>value`
    - note the `[]` which tell the qs parser to expect/allow multiple values to be set 
- the current query component will remove the appropriate item from the url qs when its corresponding active filter button clicked
- the sidebar filter list facet component will either add or remove the appropriate item from the url qs when its corresponding input is toggled
- on app load the expand / collapse state of the search filters and facets will be determined by the presence / absence (respectively) of the corresponding field as a qs param
- on Clear All facets/filters, any facet/filter qs params will be removed, their corresponding toggle collapsed, and a new URL (with just the search term) will be added to the browser window history.

We've also abstracted and consolidated some of the logic that was once duplicated across these files into helper methods.

## To test

### Set up your drupals
1. Make sure you follow the steps in https://github.com/palantirnet/federated-search-demo/pull/20 to fix your index and ensure that federated terms are added to the index

### Get your local app environment set up
1. Pull this branch down
1. Update [the version of the search app dependency](https://github.com/palantirnet/solr-faceted-search-react/pull/7) with `yarn install`

### Confirm: on app load, the state of federated terms (and site name and type) will be set based on any terms passed in:
1. Reload the app with populated site name, type, and one of each of the federated term group items by pasting this url into your browser: `http://localhost:3000/?search=veg%2A&sm_federated_terms[]=Dietary%20Needs%3EVegetarian&sm_federated_terms[]=Recipe%20Category%3EDessert&sm_site_name[]=Federated%20Search%20Demo%20%28D8%2C%20single%29&ss_federated_type[]=Recipe`
    1. Here are the params, broken down:
        1. `search=veg%2A`
		1. `sm_federated_terms[]=Dietary%20Needs%3EVegetarian`
		1. `sm_federated_terms[]=Recipe%20Category%3EDessert`
		1. `sm_site_name[]=Federated%20Search%20Demo%20%28D8%2C%20single%29`
		1. `ss_federated_type=Recipe`
1. Observe upon app load that the state of the field inputs (search term and sidebar filters) and current query (the button links under the search term input) accurately reflect the values passed in

### Confirm: the current query component removes the appropriate item from the url qs when its corresponding active filter button clicked
1. Click on each of the current query links one by one and observe its corresponding qs param is removed from the url

### Confirm: the sidebar filter list facet component will either add or remove the appropriate item from the url qs when its corresponding input is toggled
1. Click on various list facet inputs from the sidebar filter (i.e. any but the date filter, which is not currently tracked in the url)
1. Observe the url updates accordingly by either adding or removing the qs param name + value

### Confirm: on app load the expand / collapse state of the search filters and facets will be determined by the presence / absence (respectively) of the corresponding field as a qs param

1. Reload the app with populated site name, type, and one of each of the federated term group items by pasting this url into your browser: `http://localhost:3000/?search=veg%2A&sm_federated_terms[]=Dietary%20Needs%3EVegetarian&sm_federated_terms[]=Recipe%20Category%3EDessert&sm_site_name[]=Federated%20Search%20Demo%20%28D8%2C%20single%29&ss_federated_type[]=Recipe`
1. Observe the corresponding toggles are open

### Confirm: on Clear All facets/filters, any facet/filter qs params will be removed, their corresponding toggle collapsed, and a new URL (with just the search term) will be added to the browser window history.

1. Reload the app with populated site name, type, and one of each of the federated term group items by pasting this url into your browser: `http://localhost:3000/?search=veg%2A&sm_federated_terms[]=Dietary%20Needs%3EVegetarian&sm_federated_terms[]=Recipe%20Category%3EDessert&sm_site_name[]=Federated%20Search%20Demo%20%28D8%2C%20single%29&ss_federated_type[]=Recipe`
1. Click the "Clear All" button at the bottom of the sidebar filters
1. Observe:
    1. all qs params for facets/filters removed
    1. all expanded toggles are now collapsed
    1. you can use the browser back / next button to revisit the prior state and then get back to this state


## Remaining tasks
- Update the query + autocomplete query builders to remove any setting of a search field in the query and to optionally make a wildcard search for autocomplete