### PR TITLE
ROOT-198: remove default field from queries, make autocomplete wildcard* configurable

### DIFF
--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -46,11 +46,11 @@ module.exports = {
   //   'ds_federated_date',
   //   'sm_federated_terms',
   // ],
-  // OPTIONAL: Provides config for adding autocomplete functionality to text search
+  // OPTIONAL: Provides config for adding autocomplete functionality to text search, defaults to false
   // autocomplete : {
   //   url: <your-endpoint-for-autocomplete-results>, // required @todo document accepted types
-  //   queryField: 'tem_suggestion_title', // REQUIRED
-  //   suggestionRows: 5, // REQUIRED: no current default set
+  //   appendWildcard: true, // OPTIONAL: defaults to false, whether or not to append wildcard to query term
+  //   suggestionRows: 5, // OPTIONAL: defaults to 5
   //   numChars: 2, // OPTIONAL: defaults to 2, number of characters *after* which autocomplete results should appear
   //   mode: 'result', // REQUIRED: show search-as-you-type results ('result', default) or search term ('term') suggestions
   //   result: { // OPTIONAL: define result based autocomplete-specific config

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -59,7 +59,7 @@ module.exports = {
   //   },
   //   term: { // OPTIONAL: define term based autocomplete-specific config
   //     titleText: 'What would you like to search for?', // OPTIONAL: default set
-  //     showDirectionsText: true, // OPTIONAL: defaults to false
+  //     showDirectionsText: false, // OPTIONAL: defaults to true
   //   },
   // },
 };

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -178,14 +178,14 @@ class FederatedTextSearchAsYouType extends React.Component {
       ? this.props.autocomplete.result.titleText
       : 'What are you looking for?';
     const resultShowDirectionsText = hasResultModeConfig
-      && this.props.autocomplete.result.showDirectionsText
+      && Object.hasOwnProperty.call(this.props.autocomplete.result, 'showDirectionsText')
       ? this.props.autocomplete.result.showDirectionsText
       : true;
     const termTitleText = hasTermModeConfig && this.props.autocomplete.term.titleText
       ? this.props.autocomplete.term.titleText
       : 'Suggested search terms';
     const termShowDirectionsText = hasTermModeConfig
-      && this.props.autocomplete.term.showDirectionsText
+      && Object.hasOwnProperty.call(this.props.autocomplete.term, 'showDirectionsText')
       ? this.props.autocomplete.term.showDirectionsText
       : true;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7410,7 +7410,7 @@ sockjs@0.3.18:
 
 "solr-faceted-search-react@git+ssh://git@github.com:palantirnet/solr-faceted-search-react#root-138-autocomplete":
   version "0.12.1"
-  resolved "git+ssh://git@github.com:palantirnet/solr-faceted-search-react#82eb9366e0650b43be57565139da296ffc62e565"
+  resolved "git+ssh://git@github.com:palantirnet/solr-faceted-search-react#f0df9079a3a0e56d866ff2640c780decc645617a"
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"


### PR DESCRIPTION
This PR implements latest updates to https://github.com/palantirnet/solr-faceted-search-react/pull/7 which makes the search app un-opinionated about main + autocomplete query default / query fields.  This allows flexibility with the default search, autocomplete, and enables field boosting to be set in solr config.

Queries now have the following structure:
- main query: `q=<mainQueryField.value>` as opposed to `q=tm_rendered_item:<mainQueryField.value>`
- autocomplete query when `autocomplete.appendWildcard` is true: `q=<mainQueryField.value>+<mainQueryField.value>*&df=mainQueryField.field` 
- autocomplete query when `autocomplete.appendWildcard` is false (default): `q=<mainQueryField.value>`

See [the updates to the solr client repo tests](https://github.com/palantirnet/solr-faceted-search-react/pull/7/commits/f0df9079a3a0e56d866ff2640c780decc645617a) for more details.

To accommodate these updates, this PR also updates the autocomplete config in the example config file.

## To Test

### Set up your drupals - if you're still set up from the last demo site PR, you should be good to go
1. Make sure you follow the steps in https://github.com/palantirnet/federated-search-demo/pull/20 to fix your index and ensure that federated terms are added to the index

### Get your local app environment set up
1. Pull this branch down
1. Update [the version of the search app dependency](https://github.com/palantirnet/solr-faceted-search-react/pull/7) with `yarn install`

### Add new `autocomplete` config
1. Observe [updates to the `src/env.local.js.example` file](https://github.com/palantirnet/federated-search-react/compare/root-198-autocomplete-component...root-198-remove-default-field-from-query?expand=1#diff-031d69d5bd943ba033e405d36ad584f3)
1. Add configuration to set `autocomplete.appendWildcard` to `true`, here is what 
 mine looks like:

```js
module.exports = {
  // REQUIRED: The default solr backend.
  // url: "https://ss826806-us-east-1-aws.measuredsearch.com:443/solr/master/select",
  url: "http://federated-search-demo.local:8983/solr/drupal8/select",
  // userpass: btoa("palantir:palantirqauser"),
  // OPTIONAL: The text to display when a search returns no results.
  // noResults: "Sorry, your search yielded no results.",
  // OPTIONAL: The text to display when the app loads with no search term.
  searchPrompt: "Please enter a search term.",
  // OPTIONAL: The number of search results to show per page.
  rows: 20,
  // OPTIONAL: The number of page buttons to show for pagination.
  paginationButtons: 5,
  // OPTIONAL: Machine name of those search fields whose facets/filter and current values should be hidden in UI.
  hiddenSearchFields: [
    // 'sm_site_name',
    // 'ss_federated_type',
    // 'ds_federated_date',
    // 'sm_federated_terms',
  ],
  // OPTIONAL: Provides config for adding autocomplete functionality to text search
  autocomplete: {
    url: 'http://federated-search-demo.local:8983/solr/drupal8/select',
    appendWildcard: true,
    suggestionRows: 5,
    numChars: 2,
    mode: 'result',
    result: {
      titleText: 'What are you interested in?',
      showDirectionsText: true,
    },
  }
};
```

### Verify when `autocomplete.appendWildcard = true` a wildcard query is sent
1. Start the app with `yarn start`
1. The search app should load in a new browser window
1. Open your browser devTools (`COMMAND + alt + i`) for chrome / firefox
1. Click the Network tab of your devtools
1. Ensure that you aren't filtering any network requests by type, or at least ensure XHR is included in your filter
    - Chrome:
        ![image](https://user-images.githubusercontent.com/3279883/53520830-93c94700-3aa4-11e9-9200-fc4307de11d0.png)
    - Firefox:
        ![image](https://user-images.githubusercontent.com/3279883/53520891-c115f500-3aa4-11e9-9580-d1fb621a23c2.png)
1. Refresh the page to start logging network traffic
#### Confirm: Single word/chunks are sent with `chunk+chunk*`
1. Type `car` into the search field
1. Observe there are 5 results returned
1. Click on the request for the autocomplete query request
1. Browse to the params / form data (if you can view source vs parsed it will be most helpful)
1. Observe the query `q` param is `car car*`
1. Observe there is no default field param sent `&df=`
   ![image](https://user-images.githubusercontent.com/3279883/53741526-9d67fb80-3e64-11e9-9887-43ecd984660c.png)
#### Confirm: Single world/chunks ending in a space are trimmed
1. Type `car ` (note trailing space) into the search field
1. Observe the same 5 results are returned
1. Click on the request for the autocomplete query request
1. Browse to the params / form data  (if you can view source vs parsed it will be most helpful)
1. Observe the query `q` param is still `car car*`
1. Observe there is no default field param sent `&df=`
    ![image](https://user-images.githubusercontent.com/3279883/53741560-af499e80-3e64-11e9-8f4b-038444a0f29e.png)
#### Confirm multiple word/chunks are sent with `word1+chunk2+chunk2*`
1. Type `so  m` into the search field
1. Click on the request for the autocomplete query request
1. Browse to the params / form data (if you can view source vs parsed it will be most helpful)
1. Observe the query `q` param is still `so m m*`
1. Observe there is no default field param sent `&df=`
    ![image](https://user-images.githubusercontent.com/3279883/53741606-c4bec880-3e64-11e9-94b1-316736767763.png)

### Verify when `autocomplete.appendWildcard` is either `false` or not set, no wildcard is appended to the query
1. Type `car` into the search field
1. Observe there is only 1 result returned
1. Click on the request for the autocomplete query request
1. Browse to the params / form data (if you can view source vs parsed it will be most helpful)
1. Observe the query `q` param is `car`
1. Observe there is no default field param sent `&df=`
    ![image](https://user-images.githubusercontent.com/3279883/53741736-03548300-3e65-11e9-8f9c-6756813462f4.png)

### Verify trailing spaces are still trimmed from the query
1. Type `car ` (note the trailing space) into the search field
1. Observe there is only 1 result returned
1. Click on the request for the autocomplete query request
1. Browse to the params / form data (if you can view source vs parsed it will be most helpful)
1. Observe the query `q` param is `car`
1. Observe there is no default field param sent `&df=`
	![image](https://user-images.githubusercontent.com/3279883/53741736-03548300-3e65-11e9-8f9c-6756813462f4.png)

### Verify that when no `autocomplete.suggestionRows` value is set, it defaults to 5
1. Comment out the line setting `autocomplete.suggestionRows` in your `env.local.js` file
1. Set `autocomplete.appendWildcard` to true
1. When the app reloads, type `car` into the search field
1. Observe there are 5 results returned

### Verify that the main search query no longer sets a default search field in the query: `q=tm_rendered_item:<value>`
1. Search for carrot
1. Click on the request for the search query request
1. Browse to the params / form data (if you can view source vs parsed it will be most helpful)
1. Observe the query `q` param is `carrot` and not `tm_rendered_item:carrot`
    ![image](https://user-images.githubusercontent.com/3279883/53742045-bcb35880-3e65-11e9-977d-e225737757f0.png)

