### PR TITLE
v2.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,11 @@
       "error", {
         "devDependencies": true
       }
+    ],
+    "react/jsx-filename-extension": [
+      1, {
+        "extensions": [".js", ".jsx"],
+      }
     ]
   },
   "env": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "intl": "^1.2.5"
+    "he": "1.2.0",
+    "intl": "^1.2.5",
+    "react-aria-live": "2.0.2",
+    "react-autosuggest": "9.4.3"
   }
 }

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -12,6 +12,8 @@
  * - The optional settings illustrate the default values, which are hard
  *   coded into the app.  You only need to populate them in this file to change
  *   them from what you see below.
+ *
+ * If you set autocomplete to a configuration object, there are some required items in that object noted below.
  */
 
 module.exports = {
@@ -22,9 +24,6 @@ module.exports = {
   // OPTIONAL: If the solr backend requires Basic Authentication, uncomment below and enter the username and password
   // in the btoa function as specified below. This should ONLY allow READ access, as it will be accessible client-side.
   // userpass: btoa("username:password"),
-  // OPTIONAL: The default "Site Name" facet value.
-  // Note: This value must match the "site_name" property for one of your sites.
-  siteSearch: null,
   // OPTIONAL: The text to display when a search returns no results.
   noResults: "Sorry, your search yielded no results.",
   // OPTIONAL: Whether or not to display all results on empty search.
@@ -39,4 +38,28 @@ module.exports = {
   pageTitle: null,
   // OPTIONAL: The hostname to emulate when testing.
   hostname: "example.local",
+  // OPTIONAL: Machine name of those search fields whose facets/filter and current values should be hidden in UI.
+  // Note: if their values are pre-set (i.e. sent in qs to app), they will still be sent in the query.
+  // hiddenSearchFields: [ // Defaults to [];
+  //   'sm_site_name',
+  //   'ss_federated_type',
+  //   'ds_federated_date',
+  //   'sm_federated_terms',
+  // ],
+  // OPTIONAL: Provides config for adding autocomplete functionality to text search, defaults to false
+  // autocomplete : {
+  //   url: <your-endpoint-for-autocomplete-results>, // required @todo document accepted types
+  //   appendWildcard: false, // OPTIONAL: defaults to false, whether or not to append wildcard to query term
+  //   suggestionRows: 5, // OPTIONAL: defaults to 5
+  //   numChars: 2, // OPTIONAL: defaults to 2, number of characters *after* which autocomplete results should appear
+  //   mode: 'result', // REQUIRED: show search-as-you-type results ('result', default) or search term ('term') suggestions
+  //   result: { // OPTIONAL: define result based autocomplete-specific config
+  //     titleText: 'What are you interested in?', // OPTIONAL: default set
+  //     showDirectionsText: true, // OPTIONAL: defaults to true
+  //   },
+  //   term: { // OPTIONAL: define term based autocomplete-specific config
+  //     titleText: 'What would you like to search for?', // OPTIONAL: default set
+  //     showDirectionsText: true, // OPTIONAL: defaults to true
+  //   },
+  // },
 };

--- a/src/components/_aside.scss
+++ b/src/components/_aside.scss
@@ -2,7 +2,7 @@
  * aside.scss
  * Define aside styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 aside {

--- a/src/components/_search-filters.scss
+++ b/src/components/_search-filters.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-filters__trigger,

--- a/src/components/current-query/_applied-filters.scss
+++ b/src/components/current-query/_applied-filters.scss
@@ -2,7 +2,7 @@
  * applied-filters.scss
  * Define applied filters styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .applied-filters {
@@ -13,6 +13,7 @@
 .applied-filters__filter {
   @include adjust-font-size-to($label, .8);
   padding-bottom: rhythm(.2);
+  border: 0;
   border-bottom: solid 2px $c-secondary;
   margin-right: rhythm(.5);
   margin-bottom: rhythm(.5);

--- a/src/components/current-query/index.js
+++ b/src/components/current-query/index.js
@@ -1,91 +1,49 @@
-import React from "react";
-import PropTypes from "prop-types";
-import queryString from "query-string";
-import moment from "moment";
+import React from 'react';
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+import moment from 'moment';
+import { LiveMessenger } from 'react-aria-live';
+import helpers from '../../helpers';
 
-class FederatedCurrentQuery extends React.Component {
-
-	render() {
-		const { query } = this.props;
-
-    const fields = query.searchFields
-        .filter((searchField) => searchField.value && searchField.value.length > 0);
-
-    // Create a map of known facet type child components which can be rendered dynamically.
-    const facetTypes = {
-      "list-facet": ListFacetType,
-      "range-facet": RangeFacetType,
-      "text": TextFacetType
-    };
-
-		return (
-        <React.Fragment>
-          {fields.length > 0 && // Only render this if there are filters applied.
-            <div className="applied-filters">
-              <h2 className="element-invisible">Currently Applied Search
-                Filters.</h2>
-              <p className="element-invisible">Click a filter to remove it from
-                your search query.</p>
-              {fields.map((searchField, i) => {
-               // Determine which child component to render.
-                const MyFacetType = facetTypes[searchField.type];
-                return <MyFacetType key={i} searchField={searchField} {...this.props}/>
-              })}
-            </div>
-          }
-        </React.Fragment>
-		);
-	}
-}
-
-FederatedCurrentQuery.propTypes = {
-	onChange: PropTypes.func,
-	query: PropTypes.object
-};
 
 // Create dumb component which can be configured by props.
-const FacetType = (props) => {
-  return (
-    <span className="applied-filters__filter" key={props.id} onClick={props.onClick}>
-			{props.children}
-		</span>
-  )
-};
+const FacetType = props => (
+  <button className="applied-filters__filter" key={props.id} onClick={props.onClick}>
+    <span className="element-invisible">
+      Remove filter
+    </span>
+    {props.children}
+  </button>
+);
 
 // Configure and render the FacetType component to render as list facet type.
 class ListFacetType extends React.Component {
-
   removeListFacetValue(field, values, value) {
-    const foundIdx = values.indexOf(value);
-    // Get existing querystring params.
-    let parsed = queryString.parse(window.location.search);
+    this.props.announcePolite(`Removed ${field.value} filter.`);
 
-    // Those filter fields for which we want to preserve state in qs.
-    // @todo handle parsing of terms and dates
-    // @todo store this in app config?
-    const filterFieldsWithQsState = [
-      "sm_site_name",
-      "ss_federated_type"
-    ];
+    const {
+      foundIdx,
+      parsed,
+      isQsParamField,
+      param,
+    } = helpers.qs.getFieldQsInfo({
+      field,
+      values,
+      value,
+    });
 
-    const isQsParamField = filterFieldsWithQsState.find((item) => item === field );
-
+    // Confirm the field value is set in state.
     if (foundIdx > -1) {
-      if (isQsParamField) {
-        // Remove the param for this field from the parsed qs object.
-        delete parsed[field];
-        // Update the search querystring param with the value from the search field.
-        const stringified = queryString.stringify(parsed);
-        // Update the querystring params in the browser, add path to history.
-        // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
-        if (window.history.pushState) {
-          const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + stringified;
-          window.history.pushState({path: newurl}, '', newurl);
-          console.log(newurl)
-        }
-        else {
-          window.location.search = stringified;
-        }
+      // If the field is one whose state is tracked in qs and there is currently a param for it.
+      if (isQsParamField && param) {
+        const newParsed = helpers.qs.removeValueFromQsParam({
+          field,
+          value,
+          param,
+          parsed,
+        });
+
+        helpers.qs.addNewUrlToBrowserHistory(newParsed);
       }
 
       // Send query based on new state.
@@ -94,56 +52,60 @@ class ListFacetType extends React.Component {
   }
 
   render() {
-    const {searchField} = this.props;
-    return ( searchField.value.map((val, i) => (
-        <FacetType key={i} id={i} onClick={() => this.removeListFacetValue(searchField.field, searchField.value, val)}>
-          {/* Add spacing to hierarchical facet values: Type>Term = Type > Term. */}
-          {val.replace('>',' > ')}
-        </FacetType>
-    )))
+    const { searchField } = this.props;
+    return (searchField.value.map((val, i) => (
+      <FacetType
+        key={i}
+        id={i}
+        onClick={() => this.removeListFacetValue(searchField.field, searchField.value, val)}
+      >
+        {/* Add spacing to hierarchical facet values: Type>Term = Type > Term. */}
+        {val.replace('>', ' > ')}
+      </FacetType>
+    )));
   }
 }
 
 // Configure and render the FacetType component to render as range facet type.
 class RangeFacetType extends React.Component {
-
   removeRangeFacetValue(field) {
+    this.props.announcePolite(`Removed ${field.value} filter.`);
     this.props.onChange(field, []);
   }
 
   render() {
-    const {searchField} = this.props;
+    const { searchField } = this.props;
     // Create a moment from the search start date.
     const start = moment(searchField.value[0]);
     // Use UTC.
     start.utc();
     // Create a formatted string from start date.
-    const startFormatted = start.format("MM/DD/YYYY");
+    const startFormatted = start.format('MM/DD/YYYY');
     // Create a moment from search end date.
     const end = moment(searchField.value[1]);
     // Use utc.
     end.utc();
     // Create a formatted string from end date.
-    const endFormatted = end.format("MM/DD/YYYY");
+    const endFormatted = end.format('MM/DD/YYYY');
     // Determine if we chose the same or different start / end dates.
-    const diff = start.diff(end,'days');
+    const diff = start.diff(end, 'days');
     // Only show the start date if the same date were chosen, otherwise: start - end.
-    const filterValue = diff ? startFormatted + ' - ' + endFormatted : startFormatted;
+    const filterValue = diff ? `${startFormatted} - ${endFormatted}` : startFormatted;
     return (
       <FacetType onClick={() => this.removeRangeFacetValue(searchField.field)}>
         {filterValue}
       </FacetType>
-    )
+    );
   }
 }
 
 // Configure and render the FacetType component to render as text facet type.
 class TextFacetType extends React.Component {
-
   removeTextValue(field) {
-    this.props.onChange(field, "");
+    this.props.announcePolite(`Removed search term ${field.value}.`);
+    this.props.onChange(field, '');
     // Get current querystring params.
-    let parsed = queryString.parse(window.location.search);
+    const parsed = queryString.parse(window.location.search);
     // Remove the search term param, if it exists.
     if (parsed.search) {
       delete parsed.search;
@@ -153,27 +115,78 @@ class TextFacetType extends React.Component {
     // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
     if (window.history.pushState) {
       if (stringified) {
-        const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + stringified;
-        window.history.pushState({path:newurl},'',newurl);
+        const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+        window.history.pushState({ path: newurl }, '', newurl);
+      } else {
+        const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+        window.history.pushState({ path: newurl }, '', newurl);
       }
-      else {
-        const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname;
-        window.history.pushState({path:newurl},'',newurl);
-      }
-    }
-    else {
+    } else {
       window.location.search = stringified;
     }
   }
 
   render() {
-    const {searchField} = this.props;
+    const { searchField } = this.props;
     return (
-        <FacetType onClick={() => this.removeTextValue(searchField.field)}>
-          {searchField.value}
-        </FacetType>
-    )
+      <FacetType onClick={() => this.removeTextValue(searchField.field)}>
+        {searchField.value}
+      </FacetType>
+    );
   }
 }
+
+class FederatedCurrentQuery extends React.Component {
+  render() {
+    const { query } = this.props;
+
+    const fields = query.searchFields.filter(searchField => searchField.value
+      && searchField.value.length > 0);
+
+    // Create a map of known facet type child components which can be rendered dynamically.
+    const facetTypes = {
+      'list-facet': ListFacetType,
+      'range-facet': RangeFacetType,
+      text: TextFacetType,
+    };
+
+    return (
+      <LiveMessenger>
+        {({ announcePolite }) => (
+          <React.Fragment>
+            {fields.length > 0 && // Only render this if there are filters applied.
+              <div className="applied-filters">
+                <h2 className="element-invisible">
+                  Currently Applied Search Filters.
+                </h2>
+                <p className="element-invisible">
+                  Click a filter to remove it from your search query.
+                </p>
+                {/* Only render the values for visible facets / filters */}
+                {fields.filter(searchField => !searchField.isHidden).map((searchField, i) => {
+                  // Determine which child component to render.
+                  const MyFacetType = facetTypes[searchField.type];
+                  return (
+                    <MyFacetType
+                      {...this.props}
+                      key={i}
+                      searchField={searchField}
+                      announcePolite={announcePolite}
+                    />
+                  );
+                })}
+              </div>
+            }
+          </React.Fragment>
+        )}
+      </LiveMessenger>
+    );
+  }
+}
+
+FederatedCurrentQuery.propTypes = {
+  onChange: PropTypes.func,
+  query: PropTypes.object,
+};
 
 export default FederatedCurrentQuery;

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -1,41 +1,74 @@
-import React from "react";
+import React from 'react';
 import PropTypes from 'prop-types';
-
+import { LiveAnnouncer } from 'react-aria-live';
+import FederatedSolrComponentPack from './federated_solr_component_pack';
+import helpers from '../helpers';
 //import componentPack from "./component-pack";
-import FederatedSolrComponentPack from "./federated_solr_component_pack";
 
-const getFacetValues = (type, results, field, lowerBound, upperBound) =>
-    type === "period-range-facet" ? (results.facets[lowerBound] || []).concat(results.facets[upperBound] || []) :
-        type === "list-facet" || type === "range-facet" ? results.facets[field] || [] : null;
-
+const getFacetValues = (type, results, field, lowerBound, upperBound) => {
+  return type === 'period-range-facet'
+    ? (results.facets[lowerBound] || []).concat(results.facets[upperBound] || [])
+    : type === 'list-facet' || type === 'range-facet'
+      ? results.facets[field] || []
+      : null;
+};
 
 class FederatedSolrFacetedSearch extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.resetFilters = this.resetFilters.bind(this);
+  }
 
   resetFilters() {
-    let {query} = this.props;
+    let { query } = this.props;
+    let searchTerm = '';
     // Keep only the value of the main search field.
-    for (let field of query.searchFields) {
+    for (const field of query.searchFields) {
       if (field.field !== query.mainQueryField) {
-        delete(field.value);
+        // Remove the field value.
+        delete (field.value);
+        // Collapse the sidebar filter toggle.
+        field.collapse = true;
+        // Collapse the terms sidebar filter toggle.
+        if (Object.hasOwnProperty.call(field, 'expandedHierarchies')) {
+          field.expandedHierarchies = [];
+        }
+      } else {
+        // Extract the value of the main search term to use when setting new URL for this state.
+        searchTerm = field.value;
       }
     }
+    // Set new parsed params based on only search term value.
+    const parsed = {
+      search: searchTerm,
+    };
+    // Add new url to browser window history.
+    helpers.qs.addNewUrlToBrowserHistory(parsed);
+
     // Update state to remove the filter field values.
-    this.setState({query});
+    this.setState({ query });
     // Execute search.
     this.props.onSearchFieldChange();
   }
 
   render() {
-    const { customComponents, bootstrapCss, query, results, truncateFacetListsAt } = this.props;
-    const { onSearchFieldChange, onSortFieldChange, onPageChange } = this.props;
-
+    const {
+      customComponents,
+      bootstrapCss,
+      query,
+      results,
+      truncateFacetListsAt,
+      options,
+      onSearchFieldChange,
+      onTextInputChange,
+      onSortFieldChange,
+      onPageChange,
+    } = this.props;
     const { searchFields, sortFields, rows } = query;
     const start = query.start ? query.start : 0;
-
-
     const SearchFieldContainerComponent = customComponents.searchFields.container;
     const ResultContainerComponent = customComponents.results.container;
-
     const ResultComponent = customComponents.results.result;
     const ResultCount = customComponents.results.resultCount;
     const ResultHeaderComponent = customComponents.results.header;
@@ -45,15 +78,20 @@ class FederatedSolrFacetedSearch extends React.Component {
     const PreloadComponent = customComponents.results.preloadIndicator;
     const CurrentQueryComponent = customComponents.searchFields.currentQuery;
     const SortComponent = customComponents.sortFields.menu;
-    const resultPending = results.pending ? (<ResultPendingComponent bootstrapCss={bootstrapCss} />) : null;
     const FederatedTextSearch = FederatedSolrComponentPack.searchFields.text;
 
-    const pagination = query.pageStrategy === "paginate" ?
-        <PaginateComponent {...this.props} bootstrapCss={bootstrapCss} onChange={onPageChange} /> :
-        null;
+    const resultPending = results.pending
+      ? (<ResultPendingComponent bootstrapCss={bootstrapCss} />)
+      : null;
 
-    const preloadListItem = query.pageStrategy === "cursor" && results.docs.length < results.numFound ?
-        <PreloadComponent {...this.props} /> : null;
+    const pagination = query.pageStrategy === 'paginate' ?
+      <PaginateComponent {...this.props} bootstrapCss={bootstrapCss} onChange={onPageChange} /> :
+      null;
+
+    const preloadListItem = query.pageStrategy === 'cursor'
+    && results.docs.length < results.numFound
+      ? <PreloadComponent {...this.props} />
+      : null;
 
     let pageTitle;
     if (this.props.options.pageTitle != null) {
@@ -61,64 +99,104 @@ class FederatedSolrFacetedSearch extends React.Component {
     }
 
     return (
+      <LiveAnnouncer>
         <div className="container">
           <aside className="l-25-75--1">
-            <SearchFieldContainerComponent bootstrapCss={bootstrapCss} onNewSearch={this.resetFilters.bind(this)} resultsCount={this.props.results.numFound}>
-              {searchFields.filter((searchFields) => this.props.sidebarFilters.indexOf(searchFields.field) > -1).map((searchField, i) => {
-                const { type, field, lowerBound, upperBound } = searchField;
-                const SearchComponent = customComponents.searchFields[type];
-                const facets = getFacetValues(type, results, field, lowerBound, upperBound);
+            <SearchFieldContainerComponent
+              bootstrapCss={bootstrapCss}
+              onNewSearch={this.resetFilters}
+              resultsCount={this.props.results.numFound}
+            >
+              {/* Only render the visible facets / filters.
+                  Note: their values may still be used in the query, if they were pre-set. */}
+              {searchFields
+                .filter(searchField => this.props.sidebarFilters.indexOf(searchField.field) > -1
+                  && !searchField.isHidden)
+                .map((searchField, i) => {
+                  const {
+                    type,
+                    field,
+                    lowerBound,
+                    upperBound,
+                  } = searchField;
+                  const SearchComponent = customComponents.searchFields[type];
+                  const facets = getFacetValues(type, results, field, lowerBound, upperBound);
 
-                return (<SearchComponent
-                        key={i} {...this.props} {...searchField}
-                        bootstrapCss={bootstrapCss}
-                        facets={facets}
-                        truncateFacetListsAt={truncateFacetListsAt}
-                        onChange={onSearchFieldChange} />
-                );
-              })}
+                  return (
+                    <SearchComponent
+                      key={i}
+                      {...this.props}
+                      {...searchField}
+                      bootstrapCss={bootstrapCss}
+                      facets={facets}
+                      truncateFacetListsAt={truncateFacetListsAt}
+                      onChange={onSearchFieldChange}
+                    />
+                  );
+                })
+              }
             </SearchFieldContainerComponent>
           </aside>
           <div className="l-25-75--2">
             {pageTitle}
             <div className="search-form" autoComplete="on">
               <FederatedTextSearch
-                  field="tm_rendered_item"
-                  label="Enter search term:"
-                  onChange={onSearchFieldChange}
-                  value={searchFields.find((sf) => sf.field === "tm_rendered_item").value }
+                {...this.props}
+                autocomplete={options.autocomplete}
+                field="tm_rendered_item"
+                label="Enter search term:"
+                onSuggest={onTextInputChange}
+                onChange={onSearchFieldChange}
+                value={searchFields.find(sf => sf.field === 'tm_rendered_item').value}
               />
-              <CurrentQueryComponent {...this.props} onChange={onSearchFieldChange} />
-              <SortComponent bootstrapCss={bootstrapCss} onChange={onSortFieldChange} sortFields={sortFields} />
+              <CurrentQueryComponent
+                {...this.props}
+                onChange={onSearchFieldChange}
+              />
+              <SortComponent
+                bootstrapCss={bootstrapCss}
+                onChange={onSortFieldChange}
+                sortFields={sortFields}
+              />
             </div>
-            <p className={(searchFields.find((sf) => sf.field === "tm_rendered_item").value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__prompt element-invisible' : 'solr-search-results-container__prompt'}>{this.props.options.searchPrompt || 'Please enter a search term.'}</p>
-            <div className={(searchFields.find((sf) => sf.field === "tm_rendered_item").value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__wrapper' : 'solr-search-results-container__wrapper element-invisible'}>
+            <p className={(searchFields.find(sf => sf.field === 'tm_rendered_item').value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__prompt element-invisible' : 'solr-search-results-container__prompt'}>{this.props.options.searchPrompt || 'Please enter a search term.'}</p>
+            <div className={(searchFields.find(sf => sf.field === 'tm_rendered_item').value || this.props.options.showEmptySearchResults) ? 'solr-search-results-container__wrapper' : 'solr-search-results-container__wrapper element-invisible'}>
               <ResultContainerComponent bootstrapCss={bootstrapCss}>
-              <ResultHeaderComponent bootstrapCss={bootstrapCss}>
-                <ResultCount bootstrapCss={bootstrapCss} numFound={results.numFound} start={start} rows={rows} onChange={onPageChange} noResultsText={this.props.options.noResults || null} />
-                {resultPending}
-              </ResultHeaderComponent>
-              <ResultListComponent bootstrapCss={bootstrapCss}>
-                {results.docs.map((doc, i) => (
-                    <ResultComponent bootstrapCss={bootstrapCss}
-                                     doc={doc}
-                                     fields={searchFields}
-                                     key={doc.id || i}
-                                     onSelect={this.props.onSelectDoc}
-                                     resultIndex={i}
-                                     rows={rows}
-                                     start={start}
-                                     highlight={results.highlighting[doc.id]}
-                                     hostname={this.props.options.hostname}
+                <ResultHeaderComponent bootstrapCss={bootstrapCss}>
+                  <ResultCount
+                    bootstrapCss={bootstrapCss}
+                    numFound={results.numFound}
+                    start={start}
+                    rows={rows}
+                    onChange={onPageChange}
+                    noResultsText={this.props.options.noResults || null}
+                    termValue={searchFields.find(sf => sf.field === 'tm_rendered_item').value}
+                  />
+                  {resultPending}
+                </ResultHeaderComponent>
+                <ResultListComponent bootstrapCss={bootstrapCss}>
+                  {results.docs.map((doc, i) => (
+                    <ResultComponent
+                      bootstrapCss={bootstrapCss}
+                      doc={doc}
+                      fields={searchFields}
+                      key={doc.id || i}
+                      onSelect={this.props.onSelectDoc}
+                      resultIndex={i}
+                      rows={rows}
+                      start={start}
+                      highlight={results.highlighting[doc.id]}
+                      hostname={this.props.options.hostname}
                     />
-                ))}
-                {preloadListItem}
-              </ResultListComponent>
-              {pagination}
-            </ResultContainerComponent>
+                  ))}
+                  {preloadListItem}
+                </ResultListComponent>
+                {pagination}
+              </ResultContainerComponent>
             </div>
           </div>
         </div>
+      </LiveAnnouncer>
     );
   }
 }
@@ -126,16 +204,18 @@ class FederatedSolrFacetedSearch extends React.Component {
 FederatedSolrFacetedSearch.defaultProps = {
   bootstrapCss: true,
   customComponents: FederatedSolrComponentPack,
-  pageStrategy: "paginate",
+  pageStrategy: 'paginate',
   rows: 20,
   searchFields: [
-    {type: "text", field: "*"}
+    {
+      type: 'text', field: '*',
+    },
   ],
   sortFields: [],
   truncateFacetListsAt: -1,
   showCsvExport: false,
   sidebarFilters: ['sm_site_name', 'ss_federated_type', 'ds_federated_date', 'sm_federated_terms'],
-  options: {}
+  options: {},
 };
 
 FederatedSolrFacetedSearch.propTypes = {
@@ -145,13 +225,14 @@ FederatedSolrFacetedSearch.propTypes = {
   onNewSearch: PropTypes.func,
   onPageChange: PropTypes.func,
   onSearchFieldChange: PropTypes.func.isRequired,
+  onTextInputChange: PropTypes.func,
   onSelectDoc: PropTypes.func,
   onSortFieldChange: PropTypes.func.isRequired,
   query: PropTypes.object,
   results: PropTypes.object,
   showCsvExport: PropTypes.bool,
   truncateFacetListsAt: PropTypes.number,
-  options: PropTypes.object
+  options: PropTypes.object,
 };
 
 export default FederatedSolrFacetedSearch;

--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
-import React from "react";
-import cx from "classnames";
-import queryString from "query-string";
+import React from 'react';
+import cx from 'classnames';
 import AnimateHeight from 'react-animate-height';
+import helpers from '../../helpers';
 
 
 class FederatedListFacet extends React.Component {
@@ -11,58 +11,66 @@ class FederatedListFacet extends React.Component {
     super(props);
 
     this.state = {
-      filter: "",
-      truncateFacetListsAt: props.truncateFacetListsAt
+      filter: '',
+      truncateFacetListsAt: props.truncateFacetListsAt,
     };
   }
 
   handleClick(value) {
-    const foundIdx = this.props.value.indexOf(value);
-    // Get existing querystring params.
-    let parsed = queryString.parse(window.location.search);
+    const {
+      foundIdx,
+      parsed,
+      isQsParamField,
+      param,
+    } = helpers.qs.getFieldQsInfo({
+      field: this.props.field,
+      values: this.props.value,
+      value,
+    });
 
-    // Those filter fields for which we want to preserve state in qs.
-    // @todo handle parsing of terms and dates
-    // @todo store this in app config?
-    const filterFieldsWithQsState = [
-      "sm_site_name",
-      "ss_federated_type"
-    ];
+    // Define var for new parsed qs params object.
+    let newParsed = parsed;
 
-    const isQsParamField = filterFieldsWithQsState.find((item) => item === this.props.field);
-
-    if (foundIdx < 0) {
-      // Add a param for this field to the parsed qs object.
-      if (isQsParamField) {
-        parsed[this.props.field] = value;
-      }
-
-      // Send new query based on app state.
-      this.props.onChange(this.props.field, this.props.value.concat(value));
-    }
-    else {
-      if (isQsParamField) {
-        // Remove the param for this field from the parsed qs object.
-        delete parsed[this.props.field];
-      }
-
-      // Send new query based on app state.
-      this.props.onChange(this.props.field, this.props.value.filter((v, i) => i !== foundIdx));
-    }
-
+    // If the clicked list facet field is one whose state is tracked in the qs.
     if (isQsParamField) {
-      // Update the search querystring param with the value from the search field.
-      const stringified = queryString.stringify(parsed);
-      // Update the querystring params in the browser, add path to history.
-      // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
-      if (window.history.pushState) {
-        const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + stringified;
-        window.history.pushState({path: newurl}, '', newurl);
-        console.log(newurl)
+      // If the click is adding the field value.
+      if (foundIdx < 0) {
+        // If there is already a qs param for this field value.
+        if (param) {
+          // Add value to parsed qs params.
+          newParsed = helpers.qs.addValueToQsParam({
+            field: this.props.field,
+            value,
+            param,
+            parsed,
+          });
+        } else { // If there is not already a qs param for this field value.
+          // Add new qs param for field + value.
+          newParsed = helpers.qs.addQsParam({
+            field: this.props.field,
+            value,
+            parsed,
+          });
+        }
+
+        // Send new query based on app state.
+        this.props.onChange(this.props.field, this.props.value.concat(value));
+      } else { // If the click is removing this field value.
+        // If their is already a qs param for this field value.
+        if (param) {
+          newParsed = helpers.qs.removeValueFromQsParam({
+            field: this.props.field,
+            value,
+            param,
+            parsed,
+          });
+        }
+
+        // Send new query based on app state.
+        this.props.onChange(this.props.field, this.props.value.filter((v, i) => i !== foundIdx));
       }
-      else {
-        window.location.search = stringified;
-      }
+
+      helpers.qs.addNewUrlToBrowserHistory(newParsed);
     }
   }
 
@@ -71,12 +79,12 @@ class FederatedListFacet extends React.Component {
     // If this is a hierarchical list facet.
     if (hierarchyFacetValue) {
       // Determine the current state of the expanded hierarchical list facets.
-      const indexOfExpandedHierarchyFacetValue = this.props.expandedHierarchies.indexOf(hierarchyFacetValue);
+      const indexOfExpandedHierarchyFacetValue = this.props.expandedHierarchies
+        .indexOf(hierarchyFacetValue);
       if (indexOfExpandedHierarchyFacetValue > -1) {
         // This accordion is currently expanded, so collapse it.
         this.props.expandedHierarchies.splice(indexOfExpandedHierarchyFacetValue,1);
-      }
-      else {
+      } else {
         // This accordion is currently collapsed, so expand it.
         this.props.expandedHierarchies.push(hierarchyFacetValue);
       }
@@ -84,14 +92,21 @@ class FederatedListFacet extends React.Component {
   }
 
   render() {
-    const { label, facets, field, value, collapse, hierarchy } = this.props;
+    const {
+      label,
+      facets,
+      field,
+      value,
+      collapse,
+      hierarchy,
+    } = this.props;
     const { truncateFacetListsAt } = this.state;
 
     const facetCounts = facets.filter((facet, i) => i % 2 === 1);
     const facetValues = facets.filter((facet, i) => i % 2 === 0);
     // Create an object of facets {value: count} to keep consistent for inputs.
     const facetInputs = {};
-    facetValues.forEach((value, i) => {
+    facetValues.forEach((v, i) => {
       const key = facetValues[i];
       facetInputs[key] = facetCounts[i];
     });
@@ -99,7 +114,8 @@ class FederatedListFacet extends React.Component {
     const expanded = !(collapse || false);
     const height = expanded ? 'auto' : 0;
 
-    // If we need to generate multiple list-fact accordion groups from this list-facet field (i.e. sm_federated_terms).
+    // If we need to generate multiple list-fact accordion groups
+    // from this list-facet field (i.e. sm_federated_terms).
     if (hierarchy) {
       // Iterate through sm_federated_terms array of values.
       // Each value is a string with the format Type>Term.
@@ -124,60 +140,72 @@ class FederatedListFacet extends React.Component {
         // If we don't already have terms.Type then create it.
         if (!Object.hasOwnProperty.call(terms, pieces[0])) {
           terms[pieces[0]] = {};
-          terms[pieces[0]]['items'] = [];
-          terms[pieces[0]]['expanded'] = (this.props.expandedHierarchies.indexOf(pieces[0]) > -1);
-          terms[pieces[0]]['height'] = terms[pieces[0]]['expanded'] ? 'auto' : 0;
+          terms[pieces[0]].items = [];
+          terms[pieces[0]].expanded = (this.props.expandedHierarchies.indexOf(pieces[0]) > -1);
+          terms[pieces[0]].height = terms[pieces[0]].expanded ? 'auto' : 0;
         }
         // Add the object for this facet value to the array of terms for this type.
-        terms[pieces[0]]['items'].push({term: pieces[1], facetValue: facetValue, facetCount: facetCounts[i]});
+        terms[pieces[0]].items.push({
+          term: pieces[1],
+          facetValue,
+          facetCount: facetCounts[i],
+        });
       });
 
       // Remove duplicate types
       // So facet values of "Condition>Bones", "Condition>Bone growth" should only
       // Add "Condition" type once so we only render 1 Condition accordion group.
-      const uniqueTypes = types.filter((value, index, self) => self.indexOf(value) === index).filter(String);
+      const uniqueTypes = types.filter((v, i, self) => self.indexOf(v) === i).filter(String);
 
       // Define array of accordion Lis which we'll populate with react fragments.
-      let listFacetHierarchyLis = [];
+      const listFacetHierarchyLis = [];
       // Define array of checkbox Lis which we'll populate with react fragments, per type.
-      let listFacetHierarchyTermsLis = [];
+      const listFacetHierarchyTermsLis = [];
       // Iterate through types (accordion lis).
       uniqueTypes.forEach((type, i) => {
         // Populate the checkbox lis react fragments for each type.
         listFacetHierarchyTermsLis[type] = [];
-        terms[type]['items'].forEach((termObj, i) => termObj.facetCount && listFacetHierarchyTermsLis[type].push(
-          <li key={`${termObj.term}_${termObj.facetValue}_${i}`}>
+        terms[type].items.forEach((termObj, i) => termObj.facetCount
+          && listFacetHierarchyTermsLis[type].push(<li key={`${termObj.term}_${termObj.facetValue}_${i}`}>
             <label className="search-accordion__checkbox-label">
             <input
-                type="checkbox"
-                name={type}
-                value={termObj.facetValue}
-                checked={value.indexOf(termObj.facetValue) > -1}
-                onChange={() => this.handleClick(termObj.facetValue)}
+              type="checkbox"
+              name={type}
+              value={termObj.facetValue}
+              checked={value.indexOf(termObj.facetValue) > -1}
+              onChange={() => this.handleClick(termObj.facetValue)}
             /> {termObj.term}
-            <span className="facet-item-amount"> ({termObj.facetCount})</span>
-          </label>
-        </li>));
+              <span className="facet-item-amount"> ({termObj.facetCount}
+                <span className="element-invisible">results</span>)
+              </span>
+            </label>
+          </li>));
 
         // Populate the accordion lis array with all of its checkboxes.
         listFacetHierarchyTermsLis[type].length && listFacetHierarchyLis.push(
           <li id={`solr-list-facet-${type}`} key={`solr-list-facet-${type}-${i}`}>
             <a
               tabIndex="0"
-              className={cx("search-accordion__title", {"js-search-accordion-open": terms[type]['expanded']})}
+              className={cx('search-accordion__title', { 'js-search-accordion-open': terms[type].expanded })}
               id={label.replace(/\s+/g, '-').toLowerCase()}
               onClick={this.toggleExpand.bind(this, type)}
-            >{type}</a>
+              onKeyDown={(event) => {
+                if (event.keyCode === 13) {
+                  this.toggleExpand(type);
+                }
+              }}
+            >
+              <span className="element-invisible">Toggle filter group for</span> {type}
+            </a>
             <AnimateHeight
               duration={600}
-              height={terms[type]['height']}
+              height={terms[type].height}
             >
               <ul className="search-accordion__content" key={`solr-list-facet-${type}-ul`}>
                 {listFacetHierarchyTermsLis[type]}
               </ul>
             </AnimateHeight>
-          </li>
-        );
+          </li>);
       });
       // Render the group of accordion lis with their facet value checkbox lists.
       return listFacetHierarchyLis;
@@ -187,28 +215,47 @@ class FederatedListFacet extends React.Component {
     return (
       <li id={`solr-list-facet-${field}`}>
         <a
-            tabIndex="0"
-            className={cx("search-accordion__title", {"js-search-accordion-open": expanded})}
-            id={label.replace(/\s+/g, '-').toLowerCase()}
-            onClick={this.toggleExpand.bind(this)}
-        >{label}</a>
+          tabIndex="0"
+          className={cx('search-accordion__title', { 'js-search-accordion-open': expanded })}
+          id={label.replace(/\s+/g, '-').toLowerCase()}
+          onClick={this.toggleExpand.bind(this)}
+          onKeyDown={(event) => {
+            if (event.keyCode === 13) {
+              this.toggleExpand();
+            }
+          }}
+        >
+          <span className="element-invisible">Toggle filter group for</span> {label}
+        </a>
         <AnimateHeight
           duration={600}
           height={height}
         >
           <ul className="search-accordion__content" key={`solr-list-facet-${field}-ul`}>
-            {facetValues.filter((facetValue, i) => facetInputs[facetValue] > 0 && (truncateFacetListsAt < 0 || i < truncateFacetListsAt)).map((facetValue, i) => this.state.filter.length === 0 || facetValue.toLowerCase().indexOf(this.state.filter.toLowerCase()) > -1 ? (<li key={`${facetValue}_${facetInputs[facetValue]}`}>
-              <label className="search-accordion__checkbox-label">
-              <input
-                type="checkbox"
-                name={field}
-                value={facetValue}
-                checked={value.indexOf(facetValue) > -1 ? true : false}
-                onChange={() => this.handleClick(facetValue)}
-              /> {facetValue}
-              <span className="facet-item-amount"> ({facetInputs[facetValue]})</span>
-            </label>
-            </li>) : null)}
+            {facetValues.filter((facetValue, i) => facetInputs[facetValue] > 0
+                && (truncateFacetListsAt < 0 || i < truncateFacetListsAt))
+              .map((facetValue, i) => {
+                if (this.state.filter.length === 0
+                  || facetValue.toLowerCase().indexOf(this.state.filter.toLowerCase()) > -1) {
+                  return (
+                    <li key={`${facetValue}_${facetInputs[facetValue]}`}>
+                      <label className="search-accordion__checkbox-label">
+                        <input
+                          type="checkbox"
+                          name={field}
+                          value={facetValue}
+                          checked={value.indexOf(facetValue) > -1}
+                          onChange={() => this.handleClick(facetValue)}
+                        /> {facetValue}
+                        <span className="facet-item-amount"> ({facetInputs[facetValue]}
+                          <span className="element-invisible">results</span>)
+                        </span>
+                      </label>
+                    </li>
+                  );
+                }
+                return null;
+              })}
           </ul>
         </AnimateHeight>
       </li>
@@ -219,7 +266,7 @@ class FederatedListFacet extends React.Component {
 FederatedListFacet.defaultProps = {
   hierarchy: false,
   expandedHierarchies: [],
-  value: []
+  value: [],
 };
 
 FederatedListFacet.propTypes = {
@@ -237,7 +284,7 @@ FederatedListFacet.propTypes = {
   onSetCollapse: PropTypes.func,
   query: PropTypes.object,
   truncateFacetListsAt: PropTypes.number,
-  value: PropTypes.array
+  value: PropTypes.array,
 };
 
 export default FederatedListFacet;

--- a/src/components/range-facet/index.js
+++ b/src/components/range-facet/index.js
@@ -84,6 +84,7 @@ class FederatedRangeFacet extends React.Component {
           className={cx("search-accordion__title", {"js-search-accordion-open": expanded})}
           id={label.replace(/\s+/g, '-').toLowerCase()}
           onClick={this.toggleExpand.bind(this)}
+          onKeyDown={(event)=>{if (event.keyCode === 13) {this.toggleExpand()}}}
         >{label}</a>
         <AnimateHeight
           duration={600}

--- a/src/components/results/_pagination.scss
+++ b/src/components/results/_pagination.scss
@@ -2,7 +2,7 @@
  * pagination.scss
  * Define pagination styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-pager {
 }

--- a/src/components/results/_pagination.scss
+++ b/src/components/results/_pagination.scss
@@ -5,7 +5,6 @@
  * @copyright Copyright (c) 2017 Palantir.net
  */
 .search-pager {
-  background-color: transparent;
 }
 
 .search-pager__items {
@@ -13,8 +12,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-radius: 3px;
-  background-color: $gray-pale;
   padding: 0 rhythm(2);
   margin: rhythm(3) 0;
 
@@ -39,80 +36,45 @@
     margin-right: rhythm(.25);
   }
 
-  // Link styles
-  a {
-    @include trans();
-    @include adjust-font-size-to(.9em, 1);
-    font-weight: 700;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border: 0;
-    text-align: center;
-    padding: rhythm(.25);
-
-    @include breakpoint($bp0) {
-      background-color: $c-secondary;
-      color: $white;
-      border-radius: 3px;
-      width: rhythm(1.5);
-      height: rhythm(1.5);
-      padding: 0;
-    }
-
-    @include breakpoint($bp2) {
-      @include adjust-font-size-to($label, .9);
-      width: rhythm(1.2);
-      height: rhythm(1.2);
-    }
-
-    &:hover,
-    &:active {
-      text-decoration: underline;
-      color: $white;
-      background-color: $c-secondary;
-
-      @include breakpoint($bp0) {
-        @include adjust-font-size-to($text, 1);
-        background-color: $c-secondary-dark;
-      }
-
-      svg {
-        fill: $c-primary-dark;
-      }
-    }
-
-    svg {
-      height: 1.3em;
-      fill: $white;
-      display: block;
-
-      @include breakpoint($bp0) {
-        height: 1em;
-      }
-    }
+  &.is-active .search-pager__item-link {
+    font-weight: bold;
   }
 
-  // Active page
-  &.is-active a {
-    @include adjust-font-size-to($text, 1);
-
-    @include breakpoint($bp0) {
-      background-color: $link-color;
-      color: $white;
-
-      &:hover,
-      &:active {
-        background-color: $c-primary-dark;
-      }
-    }
-  }
-
-  &.not-active {
+  &.not-active .search-pager__item-link {
     display: none;
 
     @include breakpoint($bp0) {
       display: inline-block;
+    }
+  }
+}
+
+// Link styles
+.search-pager__item-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 0;
+  text-align: center;
+  padding: rhythm(.25);
+
+  &:hover,
+  &:active {
+    text-decoration: underline;
+    svg {
+      fill: $c-primary-dark;
+      border-bottom: 1px solid $black;
+    }
+  }
+
+  svg {
+    height: 1.3em;
+    fill: $black;
+    display: block;
+    border-bottom: 1px solid transparent;
+
+    @include breakpoint($bp0) {
+      height: 1em;
     }
   }
 }

--- a/src/components/results/_search-results-stat.scss
+++ b/src/components/results/_search-results-stat.scss
@@ -6,7 +6,6 @@
  */
 
 .search-results-stat {
-  @include adjust-font-size-to(.9em, 1);
   color: $gray-medium;
 
   &:focus {

--- a/src/components/results/_search-results-stat.scss
+++ b/src/components/results/_search-results-stat.scss
@@ -2,7 +2,7 @@
  * search-results-stat.scss
  * Define search results statistic styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-results-stat {

--- a/src/components/results/_search-results.scss
+++ b/src/components/results/_search-results.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search results styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 
 .search-results {
@@ -11,12 +11,6 @@
   li {
     margin-bottom: rhythm(1);
     display: flex;
-  }
-
-  em {
-    font-style: normal;
-    font-weight: 700;
-    background-color: transparentize($c-secondary, .7);
   }
 }
 
@@ -34,46 +28,35 @@
 }
 
 .search-results__label {
-  @include adjust-font-size-to($label, .7);
-  font-weight: 500;
   color: $gray-medium;
   display: block;
 }
 
 .search-results__heading {
-  font-weight: 700;
-  @include trailer(.25, $h3-font-size);
   margin-bottom: .33333em;
   margin-top: .25em;
   padding: 0;
-  line-height: calc(100% + 50%);
+}
 
-  a {
-    /**
-   * 1. Remove the gray background on active links in IE 10.
-   * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+.search-results__heading-link {
+  /**
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ */
+  /* stylelint-disable property-no-vendor-prefix */
+  -webkit-text-decoration-skip: objects; /* 2 */
+  /* stylelint-enable */
+  color: $blue;
+  text-decoration: none;
+
+  /**
+   * Remove the outline on focused links when they are also active or hovered
+   * in all browsers (opinionated).
    */
-    @include trans();
-    background-color: transparent; /* 1 */
-    /* stylelint-disable property-no-vendor-prefix */
-    -webkit-text-decoration-skip: objects; /* 2 */
-    /* stylelint-enable */
-    color: $link-color;
-    text-decoration: none;
-    border-bottom: 2px dashed $link-color;
-
-    /**
-     * Remove the outline on focused links when they are also active or hovered
-     * in all browsers (opinionated).
-     */
-
-    &:active,
-    &:hover {
-      outline-width: 0;
-      color: $link-hover;
-      background-color: $gray-light;
-      border-bottom: 2px solid $link-hover;
-    }
+  &:active,
+  &:hover {
+    outline-width: 0;
+    text-decoration: underline;
   }
 }
 
@@ -82,12 +65,17 @@
 }
 
 .search-results__meta {
-  @include adjust-font-size-to($label, .8);
   margin-bottom: rhythm(.5);
   color: $gray-medium;
   display: block;
 }
 
-.search-results__citation {
+.search-results__citation a {
   font-style: normal;
+  color: $gray-medium;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }

--- a/src/components/results/_search-results.scss
+++ b/src/components/results/_search-results.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search results styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-results {

--- a/src/components/results/count-label.js
+++ b/src/components/results/count-label.js
@@ -1,39 +1,54 @@
 import PropTypes from 'prop-types';
-import React from "react";
+import React from 'react';
+import { LiveMessage } from 'react-aria-live';
 
-function searchResultsStat(currentPage, numFound, rows, pageAmt, noResultsText) {
+function searchResultsStat(currentPage, numFound, rows, pageAmt, noResultsText, termValue) {
+  // Set visible and a11y message based on query results.
+  let message = '';
+  let a11yMessage = '';
   if (numFound > rows) { // Many pages
-    return (
-      <p id="stat" tabIndex="-1" className="search-results-stat">Showing page <strong>{currentPage+1}</strong> of <strong>{pageAmt}</strong> (<strong>{numFound}</strong> results). </p>
-    )
+    a11yMessage = `Showing page ${currentPage + 1} of ${pageAmt} (${numFound} results).`;
+    message = (
+      <span>Showing page
+        <b> {currentPage + 1}</b> of
+        <b> {pageAmt}</b> (<b>{numFound}</b> results).
+      </span>
+    );
+  } else if (numFound <= rows && numFound > 1) { // Single page
+    a11yMessage = `Showing ${numFound} results.`;
+    message = (<span>Showing <b>{numFound}</b> results.</span>);
+  } else if (numFound === 1) { // Single item
+    a11yMessage = `Showing ${numFound} result.`;
+    message = (<span>Showing <b>{numFound}</b> result.</span>);
+  } else if (numFound === 0) { // No results
+    message = noResultsText || 'Sorry, your search yielded no results.';
+    a11yMessage = message;
   }
-  else if (numFound <= rows && numFound > 1) { // Single page
-    return (
-      <p id="stat" tabIndex="-1" className="search-results-stat">Showing <strong>{numFound}</strong> results.</p>
-    )
-  }
-  else if (numFound === 1) { // Single item
-    return (
-      <p id="stat" tabIndex="-1" className="search-results-stat">Showing <strong>{numFound}</strong> result.</p>
-    )
-  }
-  else if (numFound === 0) { // No results
-    return (
-      <p id="stat" tabIndex="-1" className="search-results-stat">{noResultsText || 'Your search yielded no results.'}</p>
-    )
-  }
+  // Don't announce total results when wildcard query sent on term clear.
+  a11yMessage = termValue ? a11yMessage : '';
+  return (
+    <React.Fragment>
+      <LiveMessage message={a11yMessage} aria-live="polite" />
+      <p id="stat" tabIndex="-1" className="search-results-stat">{message}</p>
+    </React.Fragment>
+  );
 }
 
 class FederatedCountLabel extends React.Component {
   render() {
-    const { numFound, start, rows, noResultsText } = this.props;
+    const {
+      numFound,
+      start,
+      rows,
+      noResultsText,
+      termValue,
+    } = this.props;
     const currentPage = start / rows;
     const pageAmt = Math.ceil(numFound / rows);
-
     return (
-        <React.Fragment>
-          {searchResultsStat(currentPage, numFound, rows, pageAmt, noResultsText)}
-        </React.Fragment>
+      <React.Fragment>
+        {searchResultsStat(currentPage, numFound, rows, pageAmt, noResultsText, termValue)}
+      </React.Fragment>
     );
   }
 }
@@ -41,11 +56,11 @@ class FederatedCountLabel extends React.Component {
 FederatedCountLabel.propTypes = {
   numFound: PropTypes.number.isRequired,
   start: PropTypes.number.isRequired,
-  rows: PropTypes.number
+  rows: PropTypes.number,
 };
 
 FederatedCountLabel.defaultProps = {
-  start: 0
+  start: 0,
 };
 
 export default FederatedCountLabel;

--- a/src/components/results/pagination.js
+++ b/src/components/results/pagination.js
@@ -24,7 +24,7 @@ class FederatedPagination extends React.Component {
     let isCurrentPage = page === currentPage;
     return (
       <li className={cx("search-pager__item", (isCurrentPage ? 'is-active' : 'not-active'))} key={key}>
-        <a role="button" tabIndex="0" onClick={this.onPageChange.bind(this, page)} onKeyPress={this.buildHandleEnterKeyPress(this.onPageChange.bind(this, page))} title={isCurrentPage ? "Current page" : `Go to page ${page + 1}`} aria-current={isCurrentPage ? page + 1 : undefined}>
+        <a className={cx("search-pager__item-link")} role="button" tabIndex="0" onClick={this.onPageChange.bind(this, page)} onKeyPress={this.buildHandleEnterKeyPress(this.onPageChange.bind(this, page))} title={isCurrentPage ? "Current page" : `Go to page ${page + 1}`} aria-current={isCurrentPage ? page + 1 : undefined}>
           <span className="element-invisible">Page</span>{page + 1}
         </a>
       </li>
@@ -63,16 +63,16 @@ class FederatedPagination extends React.Component {
       <nav className="search-pager" aria-labelledby="pagination-heading">
         <h4 id="pagination-heading" className="element-invisible">Pagination</h4>
         <ul className="search-pager__items">
-          <li className={cx("search-pager__item", {"element-invisible": firstPageHidden})} key="start">
-            <a role="button" tabIndex={firstPageHidden ? "-1" : "0"} onClick={this.onPageChange.bind(this, 0)} onKeyPress={ this.buildHandleEnterKeyPress(this.onPageChange.bind(this, 0)) } title="Go to first page">
+          <li className={cx("search-pager__item search-pager__item--first", {"element-invisible": firstPageHidden})} key="start">
+            <a className={cx("search-pager__item-link")} role="button" tabIndex={firstPageHidden ? "-1" : "0"} onClick={this.onPageChange.bind(this, 0)} onKeyPress={ this.buildHandleEnterKeyPress(this.onPageChange.bind(this, 0)) } title="Go to first page">
               <span className="element-invisible">First page</span>
               <span aria-hidden={firstPageHidden ? "true" : "false"}>
                 <DoubleChevronLeft/>
               </span>
             </a>
           </li>
-          <li className={cx("search-pager__item", {"element-invisible": prevPageHidden})} key="prev">
-            <a role="button" tabIndex={prevPageHidden ? "-1" : "0"} onClick={this.onPageChange.bind(this, currentPage - 1)} onKeyPress={ this.buildHandleEnterKeyPress(this.onPageChange.bind(this, currentPage - 1)) }title="Go to previous page" rel="next">
+          <li className={cx("search-pager__item search-pager__item--previous", {"element-invisible": prevPageHidden})} key="prev">
+            <a className={cx("search-pager__item-link")} role="button" tabIndex={prevPageHidden ? "-1" : "0"} onClick={this.onPageChange.bind(this, currentPage - 1)} onKeyPress={ this.buildHandleEnterKeyPress(this.onPageChange.bind(this, currentPage - 1)) }title="Go to previous page" rel="next">
               <span className="element-invisible">Previous page</span>
               <span aria-hidden={prevPageHidden  ? "true" : "false"}>
                 <ChevronLeft/>
@@ -80,16 +80,16 @@ class FederatedPagination extends React.Component {
             </a>
           </li>
           {pages.map((page, idx) => this.renderPage(page, currentPage, idx))}
-          <li className={cx("search-pager__item", {"element-invisible": nextPageHidden})} key="next">
-            <a role="button" tabIndex={nextPageHidden ? "-1" : "0"} onClick={this.onPageChange.bind(this, currentPage + 1, pageAmt)} onKeyPress={ this.buildHandleEnterKeyPress(this.onPageChange.bind(this, currentPage + 1, pageAmt)) } title="Go to next page" rel="next">
+          <li className={cx("search-pager__item search-pager__item--next", {"element-invisible": nextPageHidden})} key="next">
+            <a className={cx("search-pager__item-link")} role="button" tabIndex={nextPageHidden ? "-1" : "0"} onClick={this.onPageChange.bind(this, currentPage + 1, pageAmt)} onKeyPress={ this.buildHandleEnterKeyPress(this.onPageChange.bind(this, currentPage + 1, pageAmt)) } title="Go to next page" rel="next">
               <span className="element-invisible">Next page</span>
               <span aria-hidden={nextPageHidden ? "true" : "false"}>
                 <ChevronRight/>
               </span>
             </a>
           </li>
-          <li className={cx("search-pager__item", {"element-invisible": lastPageHidden})} key="end">
-            <a role="button" tabIndex={lastPageHidden ? "-1" : "0"} onClick={this.onPageChange.bind(this, pageAmt - 1)} onKeyPress={ this.buildHandleEnterKeyPress(this.onPageChange.bind(this, pageAmt - 1)) } title="Go to last page">
+          <li className={cx("search-pager__item search-pager__item--last", {"element-invisible": lastPageHidden})} key="end">
+            <a className={cx("search-pager__item-link")} role="button" tabIndex={lastPageHidden ? "-1" : "0"} onClick={this.onPageChange.bind(this, pageAmt - 1)} onKeyPress={ this.buildHandleEnterKeyPress(this.onPageChange.bind(this, pageAmt - 1)) } title="Go to last page">
               <span className="element-invisible">Last page</span>
               <span aria-hidden={lastPageHidden ? "true" : "false"}>
                 <DoubleChevronRight/>

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -85,12 +85,12 @@ class FederatedResult extends React.Component {
       <li onClick={() => this.props.onSelect(doc)}>
         {doc.ss_federated_image &&
         <div className="search-results__container--left">
-          <img src={doc.ss_federated_image} alt=""/>
+          <img className="search-results__image" src={doc.ss_federated_image} alt=""/>
         </div>
         }
         <div className="search-results__container--right">
           <span className="search-results__label">{doc.ss_federated_type}</span>
-          <h3 className="search-results__heading"><a href={this.getCanonicalLink(doc.sm_urls, doc.ss_url)} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
+          <h3 className="search-results__heading"><a className="search-results__heading-link" href={this.getCanonicalLink(doc.sm_urls, doc.ss_url)} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
           <div className="search-results__meta">
             <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_urls, doc.ss_site_name)}</cite>
             {this.dateFormat(doc.ds_federated_date)}

--- a/src/components/search-field-container.js
+++ b/src/components/search-field-container.js
@@ -1,11 +1,10 @@
 import PropTypes from 'prop-types';
-import React from "react";
-import cx from "classnames";
+import React from 'react';
+import cx from 'classnames';
 import AnimateHeight from 'react-animate-height';
 
 
 class FederatedSearchFieldContainer extends React.Component {
-
   constructor(props) {
     super(props);
 
@@ -14,14 +13,16 @@ class FederatedSearchFieldContainer extends React.Component {
 
     this.state = {
       // Filters are visible for large / hidden for small screens by default.
-      expanded: intFrameWidth > 900
+      expanded: intFrameWidth > 900,
     };
+
+    this.handleClick = this.handleClick.bind(this);
   }
 
   handleClick() {
     this.setState({
-      expanded: !this.state.expanded
-    })
+      expanded: !this.state.expanded,
+    });
   }
 
   render() {
@@ -30,10 +31,17 @@ class FederatedSearchFieldContainer extends React.Component {
 
     return (
       <div className="search-filters">
-        <button className={cx("search-filters__trigger", {"js-search-filters-open": this.state.expanded})} onClick={this.handleClick.bind(this)}>Filter Results</button>
+        <button
+          className={cx('search-filters__trigger', {
+            'js-search-filters-open': this.state.expanded,
+          })}
+          onClick={this.handleClick}
+        >
+            Filter Results
+        </button>
         <AnimateHeight
-            duration={450}
-            height={height}
+          duration={450}
+          height={height}
         >
           <form className="search-filters__form">
             <section className="search-accordion" aria-labelledby="section-title">
@@ -57,7 +65,7 @@ class FederatedSearchFieldContainer extends React.Component {
 
 FederatedSearchFieldContainer.propTypes = {
   children: PropTypes.array,
-  onNewSearch: PropTypes.func
+  onNewSearch: PropTypes.func,
 };
 
 export default FederatedSearchFieldContainer;

--- a/src/components/sort-menu/_search-scope.scss
+++ b/src/components/sort-menu/_search-scope.scss
@@ -2,7 +2,7 @@
  * search-scope.scss
  * Define search scope styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-scope {

--- a/src/components/text-search/_autocomplete.scss
+++ b/src/components/text-search/_autocomplete.scss
@@ -1,0 +1,140 @@
+/**
+ * autocomplete.scss
+ * Define autocomplete input + suggestion styles.
+ * @see: https://github.com/moroshko/react-autosuggest#theme-optional
+ *
+ * @copyright Copyright (c) 2017-2019 Palantir.net
+ */
+
+.search-form__autocomplete-container {
+  display: flex;
+
+  @include breakpoint($bp1) {
+    width: 75%;
+  }
+
+  @include breakpoint($bp3) {
+    width: 50%;
+  }
+
+  .search-form__input-wrapper {
+    width: 100%;
+  }
+}
+
+.react-autosuggest {
+  &__container {
+    position: relative;
+    flex: 1;
+  }
+
+  &__input {
+    @include adjust-font-size-to($label, .8);
+    flex: 1;
+    border: 1px solid $gray-light;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    height: 34px;
+    padding: .5rem;
+
+    &:focus {
+      border-color: $gray-dark;
+      outline: none;
+    }
+
+    .react-autosuggest__container--open & {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  &__suggestions-container {
+    display: none;
+  }
+
+  &__container-title {
+    @include adjust-font-size-to($label, .8);
+    position: relative;
+    font-weight: bold;
+    padding: 10px 20px;
+    border-bottom: 1px dashed $c-border-gray;
+  }
+
+  &__container-close-button {
+    @include adjust-font-size-to($label, .8);
+    font-style: normal;
+    padding: 3px 7px;
+    border-color: $c-border-gray;
+    color: $gray-dark;
+    cursor: pointer;
+    position: absolute;
+    right: 5px;
+
+    &:hover {
+      border-color: $c-border-gray-dark;
+      background-color: $c-bg-gray;
+    }
+  }
+
+  &__container-directions {
+    padding: 10px 20px;
+
+    &-item {
+      @include adjust-font-size-to($label, .8);
+      display: block;
+    }
+
+  }
+
+  &__suggestions-container--open {
+    display: block;
+    position: absolute;
+    top: 33px;
+    width: 100%;
+    border: 1px solid $gray-dark;
+    background-color: $white;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    z-index: 2;
+  }
+  &__suggestions-itemslist-wrapper--with-directions {
+    .react-autosuggest__suggestion {
+      &:last-child {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        border-bottom-color: $c-border-gray;
+      }
+    }
+  }
+
+  &__suggestions-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  &__suggestion {
+    @include adjust-font-size-to($label, .8);
+    cursor: pointer;
+    padding: 15px 20px;
+    background-color: $white;
+    border: 1px solid $white;
+    border-bottom-color: $c-border-gray;
+
+    &:last-child {
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+      border-bottom-color: $white;
+    }
+  }
+
+  &__suggestion-link {
+    color: $link-color;
+  }
+
+  &__suggestion--highlighted {
+    background-color: $c-bg-gray;
+    border: 1px solid $c-bg-gray;
+    border-bottom-color: $c-border-gray;
+  }
+}

--- a/src/components/text-search/_search-form.scss
+++ b/src/components/text-search/_search-form.scss
@@ -2,7 +2,7 @@
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
 .search-form {
@@ -43,6 +43,11 @@
 
   @include breakpoint($bp2) {
     padding: .35rem;
+  }
+
+  &:focus {
+    border-color: $gray-dark;
+    outline: none;
   }
 }
 

--- a/src/components/text-search/index.js
+++ b/src/components/text-search/index.js
@@ -1,80 +1,13 @@
-import PropTypes from 'prop-types';
-import queryString from "query-string";
-import React from "react";
-import SearchIcon from "../icons/search";
+import React from 'react';
+import FederatedTextSearchNoAutocomplete from './no-autocomplete';
+import FederatedTextSearchAsYouType from './search-as-you-type';
 
-
-class FederatedTextSearch extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      value: ""
-    };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      value: nextProps.value
-    });
-  }
-
-  handleInputChange(ev) {
-    this.setState({
-      value: ev.target.value
-    });
-  }
-
-  handleInputKeyDown(ev) {
-    if (ev.keyCode === 13) {
-      this.handleSubmit();
-    }
-  }
-
-  handleSubmit() {
-    this.props.onChange(this.props.field, this.state.value);
-    // Get existing querystring params.
-    let parsed = queryString.parse(window.location.search);
-    // Update the search querystring param with the value from the search field.
-    parsed.search = this.state.value;
-    const stringified = queryString.stringify(parsed);
-    // Update the querystring params in the browser, add path to history.
-    // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
-    if (window.history.pushState) {
-      const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + stringified;
-      window.history.pushState({path:newurl},'',newurl);
-    }
-    else {
-      window.location.search = stringified;
-    }
-  }
-
-  render() {
-    const { label } = this.props;
-
-    return (
-      <React.Fragment>
-        <label htmlFor="search" className="search-form__label">{label}</label>
-        <div className="search-form__input-wrapper">
-          <input type="search" name="search" id="search" className="search-form__input" autoFocus
-                 onChange={this.handleInputChange.bind(this)}
-                 onKeyDown={this.handleInputKeyDown.bind(this)}
-                 value={this.state.value || ""} />
-          <button type="submit" className="search-form__submit" onClick={this.handleSubmit.bind(this)}><span className="element-invisible">Perform Search</span><SearchIcon /></button>
-        </div>
-      </React.Fragment>
-    );
-  }
-}
-
-FederatedTextSearch.defaultProps = {
-  field: null
-};
-
-FederatedTextSearch.propTypes = {
-  field: PropTypes.string.isRequired,
-  label: PropTypes.string,
-  onChange: PropTypes.func,
+const FederatedTextSearch = (props) => {
+  const { autocomplete } = props;
+  const InputComponent = autocomplete
+    ? FederatedTextSearchAsYouType
+    : FederatedTextSearchNoAutocomplete;
+  return <InputComponent {...props} />;
 };
 
 export default FederatedTextSearch;

--- a/src/components/text-search/no-autocomplete.js
+++ b/src/components/text-search/no-autocomplete.js
@@ -1,0 +1,100 @@
+import PropTypes from 'prop-types';
+import queryString from 'query-string';
+import React from 'react';
+import SearchIcon from '../icons/search';
+
+// Renders plain text input and submit button for text search.
+// Rendered when env config autocomplete is not present or set to false.
+// @see /env.local.js.example
+class FederatedTextSearchNoAutocomplete extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: '',
+    };
+
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      value: nextProps.value,
+    });
+  }
+
+  handleInputChange(ev) {
+    this.setState({
+      value: ev.target.value,
+    });
+  }
+
+  handleInputKeyDown(ev) {
+    if (ev.keyCode === 13) {
+      this.handleSubmit();
+    }
+  }
+
+  handleSubmit() {
+    this.props.onChange(this.props.field, this.state.value);
+    // Get existing querystring params.
+    const parsed = queryString.parse(window.location.search);
+    // Update the search querystring param with the value from the search field.
+    parsed.search = this.state.value;
+    const stringified = queryString.stringify(parsed);
+    // Update the querystring params in the browser, add path to history.
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
+    if (window.history.pushState) {
+      const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+      window.history.pushState({ path: newUrl }, '', newUrl);
+    } else {
+      window.location.search = stringified;
+    }
+  }
+
+  render() {
+    const { label } = this.props;
+
+    return (
+      <React.Fragment>
+        <label htmlFor="search" className="search-form__label">{label}</label>
+        <div className="search-form__input-wrapper">
+          <input
+            type="search"
+            name="search"
+            id="search"
+            className="search-form__input"
+            autoFocus
+            onChange={this.handleInputChange}
+            onKeyDown={this.handleInputKeyDown}
+            value={this.state.value || ''}
+          />
+          <button
+            type="submit"
+            className="search-form__submit"
+            onClick={this.handleSubmit}>
+            <span className="element-invisible">Perform Search</span>
+            <SearchIcon />
+          </button>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+FederatedTextSearchNoAutocomplete.defaultProps = {
+  label: '',
+  onChange: () => {},
+  value: '',
+};
+
+FederatedTextSearchNoAutocomplete.propTypes = {
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  onChange: PropTypes.func,
+  value: PropTypes.string,
+};
+
+export default FederatedTextSearchNoAutocomplete;

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -1,0 +1,366 @@
+import React from 'react';
+import queryString from 'query-string';
+import he from 'he';
+import PropTypes from 'prop-types';
+import Autosuggest from 'react-autosuggest';
+import helpers from '../../helpers';
+import SearchIcon from '../icons/search';
+
+// Renders autocomplete text input and submit button for text search.
+// Rendered when env config autocomplete is present.
+// @see /env.local.js.example
+class FederatedTextSearchAsYouType extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: '',
+      suggestions: [],
+    };
+
+    this.getSuggestionValue = this.getSuggestionValue.bind(this);
+    this.handleInputKeyDown = this.handleInputKeyDown.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.loadSuggestions = this.loadSuggestions.bind(this);
+    this.onChange = this.onChange.bind(this);
+    this.onSuggestionSelected = this.onSuggestionSelected.bind(this);
+    this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(this);
+    this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(this);
+    this.renderSuggestion = this.renderSuggestion.bind(this);
+    this.renderSuggestionsContainer = this.renderSuggestionsContainer.bind(this);
+    this.shouldRenderSuggestions = this.shouldRenderSuggestions.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      value: nextProps.suggestQuery && nextProps.suggestQuery.value
+        ? nextProps.suggestQuery.value
+        : nextProps.value,
+      suggestions: nextProps.suggestions ? nextProps.suggestions.docs : this.state.suggestions,
+    });
+  }
+
+  /**
+   * Called every time the input value changes
+   *
+   * @param event
+   *   Event object
+   * @param newValue
+   *   The new value of the input
+   * @param method
+   *   String describing how the change has occurred. The possible values are:
+   *     'down' - user pressed Down
+   *     'up' - user pressed Up
+   *     'escape' - user pressed Escape
+   *     'enter' - user pressed Enter
+   *     'click' - user clicked (or tapped) on suggestion
+   *     'type' - none of the methods above (usually means that user typed something,
+   *       but can also be that they pressed Backspace, pasted something into the input, etc.)
+   */
+  onChange(event, { newValue, method }) {
+    if (method === 'type') {
+      this.setState({
+        value: newValue,
+      });
+
+      // Ensure that the suggestQuery.value prop gets cleared on backspace / cut.
+      this.props.suggestQuery.value = newValue;
+    }
+  }
+
+  // Called every time you need to recalculate suggestions.
+  onSuggestionsFetchRequested({ value }) {
+    this.loadSuggestions(value);
+  }
+
+  /**
+   * Called every time suggestion is selected via mouse or keyboard.
+   *
+   * @param event
+   *   Event object
+   * @param suggestion
+   *   The selected suggestion
+   *   Unused: suggestionValue
+   *     The value of the selected suggestion
+   *     (equivalent to getSuggestionValue(suggestion))
+   *   Unused: suggestionIndex
+   *     The index of the selected suggestion in the suggestions array
+   *   Unused: sectionIndex
+   *     When rendering multiple sections,this will be the section index
+   *     (in suggestions) of the selected suggestion. Otherwise, it will be null.
+   * @param method
+   *   String describing how user selected the suggestion. The possible values are:
+   *     'click' - user clicked (or tapped) on the suggestion
+   *     'enter' - user selected the suggestion using Enter
+   */
+  onSuggestionSelected(event, { suggestion, method }) {
+    const { mode } = this.props.autocomplete;
+    // If results are rendered, redirect to the result url and prevent search execution.
+    if (mode === 'result' && (event.keyCode === 13 || method === 'click')) {
+      event.preventDefault(); // don't submit the search query
+      event.stopPropagation(); // don't bubble up event
+      window.location.assign(suggestion.sm_urls[0]); // redirect to the selected item
+    }
+  }
+
+  // Called every time you need to set suggestions to [].
+  onSuggestionsClearRequested() {
+    this.setState({
+      suggestions: [],
+    });
+  }
+
+  // For search term autocomplete mode:
+  // When user navigates the suggestions using the Up and Down keys,
+  // the input value should be set according to the highlighted suggestion.
+  getSuggestionValue(suggestion) {
+    const { mode } = this.props.autocomplete;
+    if (mode === 'result') return false;
+    if (mode === 'term') {
+      return suggestion.ss_federated_title; // @todo get the value of the term
+    }
+    return false;
+  }
+
+  // Gets search suggestions based on input.
+  // @todo support different modes: term, results
+  loadSuggestions(value) {
+    // Run typeahead search query based on the autocomplete config and current value.
+    this.props.onSuggest(this.props.query, this.props.autocomplete, value);
+  }
+
+  handleInputKeyDown(event) {
+    // Call submit handler when enter is pressed while text input
+    // has focused.  This functionality is prevented by the
+    // onSuggestionSelected method.
+    if (event.keyCode === 13 && !event.defaultPrevented) {
+      this.handleSubmit();
+    }
+
+    // Clear and close suggetsions.
+    if (event.keyCode === 27) {
+      this.onSuggestionsClearRequested();
+    }
+  }
+
+  // Trigger search query execution by updating the current URL based
+  // on current state.
+  handleSubmit() {
+    this.props.onChange(this.props.field, this.state.value);
+    // Get existing querystring params.
+    const parsed = queryString.parse(window.location.search);
+    // Update the search querystring param with the value from the search field.
+    parsed.search = this.state.value;
+    const stringified = queryString.stringify(parsed);
+    // Update the querystring params in the browser, add path to history.
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
+    if (window.history.pushState) {
+      const newUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+      window.history.pushState({ path: newUrl }, '', newUrl);
+    } else {
+      window.location.search = stringified;
+    }
+  }
+
+  // When the input is focused, Autosuggest will consult this function
+  // when to render suggestions. Use it, for example, if you want to
+  // display suggestions when input value is at least 2 characters long.
+  shouldRenderSuggestions(value) {
+    const numChars = this.props.autocomplete.numChars || 2;
+    return value.trim().length > numChars;
+  }
+
+  renderSuggestionsContainer({ containerProps, children, query }) {
+    const { mode } = this.props.autocomplete;
+    const hasResultModeConfig = Object.hasOwnProperty.call(this.props.autocomplete, 'result');
+    const hasTermModeConfig = Object.hasOwnProperty.call(this.props.autocomplete, 'term');
+    const resultTitleText = hasResultModeConfig && this.props.autocomplete.result.titleText
+      ? this.props.autocomplete.result.titleText
+      : 'What are you looking for?';
+    const resultShowDirectionsText = hasResultModeConfig
+      && Object.hasOwnProperty.call(this.props.autocomplete.result, 'showDirectionsText')
+      ? this.props.autocomplete.result.showDirectionsText
+      : true;
+    const termTitleText = hasTermModeConfig && this.props.autocomplete.term.titleText
+      ? this.props.autocomplete.term.titleText
+      : 'Suggested search terms';
+    const termShowDirectionsText = hasTermModeConfig
+      && Object.hasOwnProperty.call(this.props.autocomplete.term, 'showDirectionsText')
+      ? this.props.autocomplete.term.showDirectionsText
+      : true;
+
+    const titleText = mode === 'term' ? termTitleText : resultTitleText;
+    const directionsText = mode === 'term' ? termShowDirectionsText : resultShowDirectionsText;
+
+    const suggestionsWrapperClasses = directionsText
+      ? 'react-autosuggest__suggestions-itemslist-wrapper react-autosuggest__suggestions-itemslist-wrapper--with-directions'
+      : 'react-autosuggest__suggestions-itemslist-wrapper';
+
+    return (
+      <div {... containerProps}>
+        <div className="react-autosuggest__container-title">
+          {titleText}
+          <button className="react-autosuggest__container-close-button" onClick={this.onSuggestionsClearRequested}>x</button>
+        </div>
+        <div className={suggestionsWrapperClasses}>
+          {children}
+        </div>
+        {/* @todo add logic for suggestion mode and alter directionsText accordingly */}
+        {directionsText &&
+          <div className="react-autosuggest__container-directions">
+            <span className="react-autosuggest__container-directions-item">Press <code>ENTER</code> to search for <strong>{query}</strong> or <code>ESC</code> to close.</span>
+            <span className="react-autosuggest__container-directions-item">Press ↑ and ↓ to highlight a suggestion then <code>ENTER</code> to be redirected to that suggestion.</span>
+          </div>
+        }
+      </div>
+    );
+  }
+
+  /**
+   * Define how suggestions are rendered.
+   * Note: must be a pure function.
+   *
+   * @param suggestion
+   *   The suggestion to render
+   *
+   * @param query
+   *   Used to highlight the matching string. As user types in the input,
+   *   query will be equal to the trimmed value of the input. Then, if user
+   *   interacts using the Up or Down keys, the input will get the value of
+   *   the highlighted suggestion, but query will remain to be equal to the
+   *   trimmed value of the input prior to the Up and Down interactions.
+   *
+   * unused - isHighlighted
+   *   Whether or not the suggestion is highlighted.
+   *
+   * @return a ReactElement
+   */
+  renderSuggestion(suggestion, { query }) {
+    // Determine if we are returning results or terms. @todo or both
+    const { mode } = this.props.autocomplete;
+    // Decode any html entities that come from title.
+    const decodedTitle = he.decode(suggestion.ss_federated_title);
+    // Wrap the query partial string in <b>.
+    const highlightedTitle = helpers.highlightText(decodedTitle, query);
+    // Define a11y message i.e. (1 of 3) to append to suggestion text.
+    const currentHumanIndex = this.state.suggestions.indexOf(suggestion) + 1;
+    const suggestionsLength = this.state.suggestions.length;
+
+    // Render plain text for search term suggestions.
+    // @todo update this when we have a return structure for terms.
+    if (mode === 'term') {
+      return (<span>highlightedTitle</span>);
+    }
+
+    // Defaults to result based autosuggestion.
+    // Render a link for search result suggestions.
+    return (
+      <a
+        className="react-autosuggest__suggestion-link"
+        href={suggestion.sm_urls[0]}
+      >
+        {highlightedTitle}
+        <span className="element-invisible">
+          {` (${currentHumanIndex} of ${suggestionsLength})`}
+        </span>
+      </a>
+    );
+  }
+
+  // Wrap the input component with our expected wrapper.
+  static renderInputComponent(inputProps) {
+    return (
+      <div className="search-form__input-wrapper">
+        <input {...inputProps} />
+      </div>
+    );
+  }
+
+  render() {
+    const { label, suggestQuery } = this.props;
+    const { suggestions, value } = this.state;
+    // Define props for autocomplete input element.
+    const inputProps = {
+      type: 'search',
+      name: 'search',
+      id: 'search',
+      className: 'react-autosuggest__input',
+      onChange: this.onChange,
+      onKeyDown: this.handleInputKeyDown,
+      value: value || '',
+      role: 'combobox',
+      'aria-autocomplete': 'both',
+    };
+
+    return (
+      <React.Fragment>
+        <label htmlFor="search" className="search-form__label">{label}</label>
+        <div className="search-form__autocomplete-container">
+          {/* @see: https://github.com/moroshko/react-autosuggest#react-autosuggest */}
+          <Autosuggest
+            focusInputOnSuggestionClick={false}
+            getSuggestionValue={this.getSuggestionValue}
+            inputProps={inputProps}
+            onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+            onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+            onSuggestionSelected={this.onSuggestionSelected}
+            renderInputComponent={FederatedTextSearchAsYouType.renderInputComponent}
+            renderSuggestion={this.renderSuggestion}
+            renderSuggestionsContainer={this.renderSuggestionsContainer}
+            shouldRenderSuggestions={this.shouldRenderSuggestions}
+            suggestQuery={suggestQuery}
+            suggestions={suggestions}
+          />
+          <button
+            type="submit"
+            className="search-form__submit"
+            onClick={this.handleSubmit}
+          >
+            <span className="element-invisible">Perform Search</span>
+            <SearchIcon />
+          </button>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+FederatedTextSearchAsYouType.defaultProps = {
+  label: 'Enter a search term',
+  value: '',
+  suggestQuery: {
+    value: '',
+  },
+};
+
+FederatedTextSearchAsYouType.propTypes = {
+  autocomplete: PropTypes.oneOfType([
+    PropTypes.shape({
+      mode: PropTypes.string,
+      method: PropTypes.string,
+      url: PropTypes.string,
+      queryField: PropTypes.string,
+      suggestionRows: PropTypes.number,
+      numChars: PropTypes.number,
+      result: {
+        titleText: PropTypes.string,
+        showDirectionsText: PropTypes.bool,
+      },
+      term: {
+        titleText: PropTypes.string,
+        showDirectionsText: PropTypes.bool,
+      },
+    }),
+    PropTypes.bool,
+  ]).isRequired,
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  onSuggest: PropTypes.func.isRequired,
+  suggestQuery: PropTypes.shape({
+    value: PropTypes.string,
+  }),
+  value: PropTypes.string,
+};
+
+export default FederatedTextSearchAsYouType;

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,0 +1,273 @@
+import React from 'react';
+import queryString from 'query-string';
+
+/**
+ * Find and highlight relevant keywords within a block of text
+ * @param  {string} text - The text to parse
+ * @param  {string} highlight - The search keyword/partial to highlight
+ * @return {object} A JSX object containing an array of alternating strings and JSX
+ */
+const highlightText = (text, highlight) => {
+  if (!highlight.toString().trim()) {
+    return <span>{text}</span>;
+  }
+  // Split on highlight term and include term into parts, ignore case
+  const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
+  return (
+    <span> { parts.map((part, i) =>
+      (
+        <span key={i} style={part.toLowerCase() === highlight.toString().toLowerCase() ? { fontWeight: 'bold' } : {}}>
+          { part }
+        </span>
+      ))}
+    </span>);
+};
+
+// Those filter fields for which we want to preserve state in qs.
+const filterFieldsWithQsState = [
+  'sm_site_name',
+  'ss_federated_type',
+  'sm_federated_terms',
+];
+
+const qs = {
+  /**
+   * Gets the qs params as an object and broken into array of [key,value] pairs.
+   * Params with multiple values (i.e. federated terms) use the following syntax:
+   * ...&sm_federated_terms[]=value1&sm_federated_terms[]=value2
+   *
+   * @returns {{parsed: (*|*|*), params: [string, any][]}}
+   */
+  getParsedQsAndParams: () => {
+    const parsed = queryString.parse(window.location.search, { arrayFormat: 'bracket' });
+    return {
+      parsed,
+      params: Object.entries(parsed),
+    };
+  },
+  /**
+   * Determines information related this search field, its value, and state.
+   *
+   * @param field
+   *   this.props.query.searchField.field (i.e. the solr field name)
+   * @param values
+   *   this.props.query.searchField.value (i.e. the current value for the field)
+   * @param value
+   *   The value of the field with which interaction has happened.
+   * @returns object
+   *   An object with:
+   *     foundIdx: the position of the field value in question found in this field's state,
+   *     parsed: an object with parsed qs params and their values,
+   *     isQsParamField: whether or not the field in question should track state in the qs,
+   *     param: an object with the as param and value for this field, if it exists
+   */
+  getFieldQsInfo: ({ field, values, value }) => {
+    // Determine if the field value in question exists in this search field's state.
+    // i.e. was it toggled on or off?
+    const foundIdx = values.indexOf(value);
+    // Get existing querystring params.
+    const { parsed, params } = qs.getParsedQsAndParams();
+
+    // Check if the search field is one for which we preserve state through qs.
+    const isQsParamField = filterFieldsWithQsState.find(item => item === field);
+
+    // Check if the filter field exists in qs param.
+    const param = params.find(item => item[0] === field);
+
+    return {
+      foundIdx,
+      parsed,
+      isQsParamField,
+      param,
+    };
+  },
+  /**
+   * Updates the parsed object by adding the field value in question to its param key.
+   *
+   * @param field
+   *   this.props.query.searchField.field (i.e. the solr field name)
+   * @param value
+   *   The value of the field with which interaction has happened.
+   * @param param
+   *   An object with the as param and value for this field, if it exists.
+   * @param parsed
+   *   An object with parsed qs params and their values.
+   * @returns Object
+   *   An updated parsed object with the field value in question added.
+   */
+  addValueToQsParam: ({
+    field,
+    value,
+    param,
+    parsed,
+  }) => {
+    const newParsed = parsed;
+    // Handle single value params.
+    if (typeof param[1] !== 'object' && value !== param[1]) {
+      // Add the param for this field from the parsed qs object.
+      newParsed[field] = value;
+    }
+    // Handle multi value params.
+    if (typeof param[1] === 'object' && !param[1].includes(value)) {
+      // Add the list item facet value to the param value.
+      param[1].push(value);
+      // Set the new param value.
+      newParsed[field] = [...param[1]];
+    }
+    return newParsed;
+  },
+  /**
+   * Updates the parsed object by adding the field and its value to the
+   *   current object of params and their values.
+   *
+   * @param field
+   *   this.props.query.searchField.field (i.e. the solr field name)
+   * @param value
+   *   The value of the field with which interaction has happened.
+   * @param param
+   *   An object with the as param and value for this field, if it exists.
+   * @param parsed
+   *   An object with parsed qs params and their values.
+   * @returns Object
+   *   An updated parsed object with the field + value added.
+   */
+  addQsParam: ({
+    field,
+    value,
+    parsed,
+  }) => {
+    const newParsed = parsed;
+    const fieldType = field.split('_')[0];
+    const isMultiple = fieldType.charAt(fieldType.length - 1) === 'm';
+
+    // Handle single value params.
+    if (!isMultiple) {
+      // Add the param for this field from the parsed qs object.
+      newParsed[field] = value;
+    }
+    // Handle multi value params.
+    if (isMultiple) {
+      // Set the new param value.
+      newParsed[field] = [value];
+    }
+    return newParsed;
+  },
+  /**
+   * Updates the parsed object by removing the field value in question to its param key.
+   *
+   * @param field
+   *   this.props.query.searchField.field (i.e. the solr field name)
+   * @param value
+   *   The value of the field with which interaction has happened.
+   * @param param
+   *   An object with the as param and value for this field, if it exists.
+   * @param parsed
+   *   An object with parsed qs params and their values.
+   * @returns Object
+   *   An updated parsed object with the field value in question removed.
+   */
+  removeValueFromQsParam: ({
+    field,
+    value,
+    param,
+    parsed,
+  }) => {
+    const newParsed = parsed;
+    // Remove value from parsed qs params.
+    // Handle single value params.
+    if (typeof param[1] !== 'object' && value === param[1]) {
+      // Remove the param for this field from the parsed qs object.
+      delete newParsed[field];
+    }
+    // Handle multi value params.
+    if (typeof param[1] === 'object' && param[1].includes(value)) {
+      // Remove the list facet value from the param.
+      newParsed[field] = param[1].filter(item => item !== value);
+    }
+
+    return newParsed;
+  },
+  /**
+   * Updates the browser window.history with an entry based on the new parsed qs params and values.
+   *
+   * @param parsed
+   *   An object with parsed qs params and their values.
+   */
+  addNewUrlToBrowserHistory: (parsed) => {
+    // Update the search querystring param with the value from the search field.
+    const stringified = queryString.stringify(parsed, { arrayFormat: 'bracket' });
+    // Update the querystring params in the browser, add path to history.
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method
+    if (window.history.pushState) {
+      const newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${stringified}`;
+      window.history.pushState({ path: newurl }, '', newurl);
+    } else {
+      window.location.search = stringified;
+    }
+  },
+  /**
+   * Sets query.searchFields state based on the state of the qs.
+   * Allows searches to be executed on app load based on URL.
+   *
+   * @param params
+   *   QS params broken into array of [key,value] pairs.
+   * @param searchField
+   *   Search field in question. (this.props.query.searchField)
+   * @returns Object
+   *   Updated this.props.query.searchField based on qs param values.
+   */
+  setFieldStateFromQs: ({
+    params,
+    searchField,
+  }) => {
+    // Make a copy of the searchField arg.
+    const newSearchField = searchField;
+    // Check if the filter field exists in qs params.
+    const param = params.find(item => item[0] === searchField.field);
+    // Check if the filter field is sm_federated_terms.
+    // If searchField has corresponding qs param present.
+    if (param) {
+      // Since there is a param for this search field, set it's toggle group to be open.
+      // Note: sm_federated_terms needs to list active "parents".
+      // See below in logic for multivalue fields.
+      newSearchField.collapse = false;
+      // Ensure we can push to searchField value.
+      newSearchField.value = searchField.value || [];
+      // Don't add qs param values if they're already set in app state.
+      // Push single values onto the searchField.value array.
+      if (typeof param[1] !== 'object' && !searchField.value.find(item => item === param[1])) {
+        newSearchField.value.push(decodeURI(param[1]));
+      }
+      // Concatenate existing searchField.value array with multivalue param array..
+      if (typeof param[1] === 'object' && searchField.value !== param[1]) {
+        const isFederatedTerms = searchField.field === 'sm_federated_terms';
+        if (isFederatedTerms) {
+          const expandedHierarchies = [];
+          param[1].forEach((item) => {
+            // Add the first part of the term to indicate it's toggle should be open.
+            expandedHierarchies.push(item.split('>')[0]);
+          });
+          // Set tm_federated_terms expanded hierarchies.
+          newSearchField.expandedHierarchies = expandedHierarchies;
+        }
+        // Decode param values.
+        const decodedParam = param[1].map(item => decodeURI(item));
+        // Set the searchField.value to the new decoded param values.
+        newSearchField.value = [...decodedParam];
+      }
+    } else {
+      // If the searchField does not have qs param present, clear its value in state.
+      delete newSearchField.value;
+      // Set its sidebar toggle group to be closed.
+      newSearchField.collapse = true;
+    }
+
+    return newSearchField;
+  },
+};
+
+export default {
+  highlightText,
+  filterFieldsWithQsState,
+  qs,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 // index.js
 import 'babel-polyfill';
-import queryString from "query-string";
-import React from "react";
-import ReactDOM from "react-dom";
-import { SolrClient } from "./solr-faceted-search-react/src/index";
-import FederatedSolrComponentPack from "./components/federated_solr_component_pack";
-import FederatedSolrFacetedSearch from "./components/federated-solr-faceted-search";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { SolrClient } from './solr-faceted-search-react/src/index';
+import FederatedSolrComponentPack from './components/federated_solr_component_pack';
+import FederatedSolrFacetedSearch from './components/federated-solr-faceted-search';
+import helpers from './helpers';
 
 // import search app boilerplate styles
 import './styles.css';
@@ -19,63 +19,32 @@ import './styles.css';
  *   Config options, used to determine initial site search name
  */
 const searchFromQuerystring = (solrClient, options = {}) => {
-  // Get the qs params, break into array of [key,value] pairs
-  const parsed = queryString.parse(window.location.search);
-  const params = Object.entries(parsed);
+  // Get existing querystring params.
+  const { parsed, params } = helpers.qs.getParsedQsAndParams();
 
   let searchFieldsState = solrClient.state.query.searchFields;
 
-  // The querystring key for search terms is 'search' (i.e. ?search=search%20term)
-  if (Object.prototype.hasOwnProperty.call(parsed,'search')) {
+  // Set the state for searchFields based on qs params.
+  searchFieldsState.forEach((searchField) => {
+    // Get the field machine name for the main query field.
+    if (Object.prototype.hasOwnProperty.call(options,'mainQueryField') && searchField.field === options.mainQueryField) {
+      // Set the state of the main query field to the value of the search qs param
+      searchField.value = parsed.search;
+    }
 
-    // Set the state for searchFields based on qs params.
-    searchFieldsState.forEach((searchField) => {
-      // Get the field machine name for the main query field.
-      if (Object.prototype.hasOwnProperty.call(options,'mainQueryField') && searchField.field === options.mainQueryField) {
-        // Set the state of the main query field to the value of the search qs param
-        searchField.value = parsed.search;
-      }
+    // If the searchField is one for which we preserve state through qs.
+    if (helpers.filterFieldsWithQsState.find((filterField) => filterField === searchField.field )) {
+      searchField = helpers.qs.setFieldStateFromQs({
+        params,
+        searchField
+      })
+    }
+  });
 
-      // Define those filter fields for which we want to preserve state in qs.
-      // @todo handle parsing of terms and dates
-      // @todo store this in app config?
-      const filterFieldsWithQsState = [
-        "sm_site_name",
-        "ss_federated_type"
-      ];
-
-      // If the searchField is one for which we preserve state through qs.
-      if (filterFieldsWithQsState.find((filterField) => filterField === searchField.field )) {
-        // Check if the filter field exists in qs params.
-        const param = params.find((item) => item[0] === searchField.field);
-        // If searchField has corresponding qs param present.
-        if (param) {
-          // Ensure we can push to searchField value.
-          searchField.value = searchField.value || [];
-          // Don't add qs param values if they're already set in app state.
-          // i.e. don't set the value twice
-          if (!searchField.value.find((item) => item === param[1])) {
-            searchField.value.push(param[1]);
-          }
-        }
-        // If the searchField does not have qs param present, clear its value in state.
-        else {
-          delete searchField.value;
-        }
-      }
-    });
-
-    // Ensure the initial query succeeds by setting a default start value.
-    solrClient.state.query.start = solrClient.state.query.start || 0;
-    // Send query based on state derived from querystring.
-    solrClient.sendQuery(solrClient.state.query);
-  }
-  // Reset search fields, fetches all results from solr. Note: results will be hidden
-  // since there is no search term.  See: federated-solr-faceted-search where
-  // ResultContainerComponent is rendered.
-  else {
-    solrClient.resetSearchFields();
-  }
+  // Ensure the initial query succeeds by setting a default start value.
+  solrClient.state.query.start = solrClient.state.query.start || 0;
+  // Send query based on state derived from querystring.
+  solrClient.sendQuery(solrClient.state.query);
 };
 
 // Initialize the solr client + search app with settings.
@@ -85,11 +54,11 @@ const init = (settings) => {
     url: "",
     // The search fields and filterable facets.
     searchFields: [
-      {label: "Enter Search Term:", field: "tm_rendered_item", type: "text"},
-      {label: "Site Name", field: "sm_site_name", type: "list-facet", collapse: true},
-      {label: "Type", field: "ss_federated_type", type: "list-facet", collapse: true},
-      {label: "Date", field: "ds_federated_date", type: "range-facet", collapse: true},
-      {label: "Federated Terms", field: "sm_federated_terms", type: "list-facet", hierarchy: true},
+      {label: "Enter Search Term:", field: "tm_rendered_item", type: "text", isHidden: false},
+      {label: "Site Name", field: "sm_site_name", type: "list-facet", collapse: true, isHidden: false},
+      {label: "Type", field: "ss_federated_type", type: "list-facet", collapse: true, isHidden: false},
+      {label: "Date", field: "ds_federated_date", type: "range-facet", collapse: true, isHidden: false},
+      {label: "Federated Terms", field: "sm_federated_terms", type: "list-facet", hierarchy: true, expandedHierarchies: [], isHidden: false},
     ],
     // The solr field to use as the source for the main query param "q".
     mainQueryField: "tm_rendered_item",
@@ -106,9 +75,20 @@ const init = (settings) => {
     rows: 20,
     // Hostname overridable in ./.env.local.js for testing purposes.
     hostname: window.location.hostname,
+    autocomplete: false,
   };
 
   const options = Object.assign(defaults, settings);
+
+  // Update searchFields to indicate which facets or filters should be hidden in the UI.
+  // Note: these facets and filters may still be used in the query.
+  settings.hiddenSearchFields = settings.hiddenSearchFields || [];
+  options.searchFields = options.searchFields.map(searchField => {
+    if (settings.hiddenSearchFields.includes(searchField.field)) {
+      searchField.isHidden = true;
+    }
+    return searchField;
+  });
 
   // The client class
   const solrClient = new SolrClient({

--- a/src/styles.css
+++ b/src/styles.css
@@ -1117,7 +1117,7 @@ textarea {
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-form {
   margin-bottom: 2.93333em; }
@@ -1154,6 +1154,9 @@ textarea {
   @media (min-width: 900px) {
     .search-form__input {
       padding: .35rem; } }
+  .search-form__input:focus {
+    border-color: #333;
+    outline: none; }
 
 .search-form__submit {
   padding: .5rem .7rem;
@@ -1176,10 +1179,122 @@ textarea {
     fill: #fff; }
 
 /**
+ * autocomplete.scss
+ * Define autocomplete input + suggestion styles.
+ * @see: https://github.com/moroshko/react-autosuggest#theme-optional
+ *
+ * @copyright Copyright (c) 2017-2019 Palantir.net
+ */
+.search-form__autocomplete-container {
+  display: flex; }
+  @media (min-width: 600px) {
+    .search-form__autocomplete-container {
+      width: 75%; } }
+  @media (min-width: 1100px) {
+    .search-form__autocomplete-container {
+      width: 50%; } }
+  .search-form__autocomplete-container .search-form__input-wrapper {
+    width: 100%; }
+
+.react-autosuggest__container {
+  position: relative;
+  flex: 1; }
+
+.react-autosuggest__input {
+  font-size: 0.8em;
+  line-height: 1.46667em;
+  flex: 1;
+  border: 1px solid #e5e5e5;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  height: 34px;
+  padding: .5rem; }
+  .react-autosuggest__input:focus {
+    border-color: #333;
+    outline: none; }
+  .react-autosuggest__container--open .react-autosuggest__input {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0; }
+
+.react-autosuggest__suggestions-container {
+  display: none; }
+
+.react-autosuggest__container-title {
+  font-size: 0.8em;
+  line-height: 1.46667em;
+  position: relative;
+  font-weight: bold;
+  padding: 10px 20px;
+  border-bottom: 1px dashed #ccc; }
+
+.react-autosuggest__container-close-button {
+  font-size: 0.8em;
+  line-height: 1.46667em;
+  font-style: normal;
+  padding: 3px 7px;
+  border-color: #ccc;
+  color: #333;
+  cursor: pointer;
+  position: absolute;
+  right: 5px; }
+  .react-autosuggest__container-close-button:hover {
+    border-color: #b5b5b5;
+    background-color: #f6f6f6; }
+
+.react-autosuggest__container-directions {
+  padding: 10px 20px; }
+  .react-autosuggest__container-directions-item {
+    font-size: 0.8em;
+    line-height: 1.46667em;
+    display: block; }
+
+.react-autosuggest__suggestions-container--open {
+  display: block;
+  position: absolute;
+  top: 33px;
+  width: 100%;
+  border: 1px solid #333;
+  background-color: #fff;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  z-index: 2; }
+
+.react-autosuggest__suggestions-itemslist-wrapper--with-directions .react-autosuggest__suggestion:last-child {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-color: #ccc; }
+
+.react-autosuggest__suggestions-list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none; }
+
+.react-autosuggest__suggestion {
+  font-size: 0.8em;
+  line-height: 1.46667em;
+  cursor: pointer;
+  padding: 15px 20px;
+  background-color: #fff;
+  border: 1px solid #fff;
+  border-bottom-color: #ccc; }
+  .react-autosuggest__suggestion:last-child {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-bottom-color: #fff; }
+
+.react-autosuggest__suggestion-link {
+  color: #737373; }
+
+.react-autosuggest__suggestion--highlighted {
+  background-color: #f6f6f6;
+  border: 1px solid #f6f6f6;
+  border-bottom-color: #ccc; }
+
+/**
  * search-form.scss
  * Define search form styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-filters__trigger,
 .search-accordion__title {
@@ -1367,7 +1482,7 @@ textarea {
  * aside.scss
  * Define aside styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 aside {
   margin-bottom: 1.46667em;
@@ -1380,7 +1495,7 @@ aside {
  * search-form.scss
  * Define search results styles.
  *
- * @copyright Copyright (c) 2019 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-results li {
   margin-bottom: 1.46667em;
@@ -1440,7 +1555,7 @@ aside {
  * search-scope.scss
  * Define search scope styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-scope {
   margin: 1.46667em 0; }
@@ -1534,7 +1649,7 @@ aside {
  * pagination.scss
  * Define pagination styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-pager__items {
   display: flex;
@@ -1591,7 +1706,7 @@ aside {
  * search-results-stat.scss
  * Define search results statistic styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .search-results-stat {
   color: #555; }
@@ -1602,7 +1717,7 @@ aside {
  * applied-filters.scss
  * Define applied filters styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .applied-filters {
   margin: 1.46667em 0;
@@ -1612,6 +1727,7 @@ aside {
   font-size: 0.8em;
   line-height: 1.46667em;
   padding-bottom: 0.29333em;
+  border: 0;
   border-bottom: solid 2px #0000ff;
   margin-right: 0.73333em;
   margin-bottom: 0.73333em;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1380,16 +1380,11 @@ aside {
  * search-form.scss
  * Define search results styles.
  *
- * @copyright Copyright (c) 2017 Palantir.net
+ * @copyright Copyright (c) 2019 Palantir.net
  */
 .search-results li {
   margin-bottom: 1.46667em;
   display: flex; }
-
-.search-results em {
-  font-style: normal;
-  font-weight: 700;
-  background-color: rgba(0, 0, 255, 0.3); }
 
 .search-results__container--left {
   flex: 1 0 0;
@@ -1399,56 +1394,47 @@ aside {
   flex: 3 0 0; }
 
 .search-results__label {
-  font-size: 0.8em;
-  line-height: 1.28333em;
-  font-weight: 500;
   color: #555;
   display: block; }
 
 .search-results__heading {
-  font-weight: 700;
-  margin-bottom: 0.36667em;
   margin-bottom: .33333em;
   margin-top: .25em;
-  padding: 0;
-  line-height: calc(100% + 50%); }
-  .search-results__heading a {
-    /**
-   * 1. Remove the gray background on active links in IE 10.
-   * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
-   */
-    transition: all 0.3s ease;
-    background-color: transparent;
-    /* 1 */
-    /* stylelint-disable property-no-vendor-prefix */
-    -webkit-text-decoration-skip: objects;
-    /* 2 */
-    /* stylelint-enable */
-    color: #737373;
-    text-decoration: none;
-    border-bottom: 2px dashed #737373;
-    /**
-     * Remove the outline on focused links when they are also active or hovered
-     * in all browsers (opinionated).
-     */ }
-    .search-results__heading a:active, .search-results__heading a:hover {
-      outline-width: 0;
-      color: black;
-      background-color: #e5e5e5;
-      border-bottom: 2px solid black; }
+  padding: 0; }
+
+.search-results__heading-link {
+  /**
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ */
+  /* stylelint-disable property-no-vendor-prefix */
+  -webkit-text-decoration-skip: objects;
+  /* 2 */
+  /* stylelint-enable */
+  color: #0000ff;
+  text-decoration: none;
+  /**
+   * Remove the outline on focused links when they are also active or hovered
+   * in all browsers (opinionated).
+   */ }
+  .search-results__heading-link:active, .search-results__heading-link:hover {
+    outline-width: 0;
+    text-decoration: underline; }
 
 .search-results__teaser {
   margin-bottom: 0.73333em; }
 
 .search-results__meta {
-  font-size: 0.8em;
-  line-height: 1.46667em;
   margin-bottom: 0.73333em;
   color: #555;
   display: block; }
 
-.search-results__citation {
-  font-style: normal; }
+.search-results__citation a {
+  font-style: normal;
+  color: #555;
+  text-decoration: none; }
+  .search-results__citation a:hover {
+    text-decoration: underline; }
 
 /**
  * search-scope.scss
@@ -1550,15 +1536,10 @@ aside {
  *
  * @copyright Copyright (c) 2017 Palantir.net
  */
-.search-pager {
-  background-color: transparent; }
-
 .search-pager__items {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-radius: 3px;
-  background-color: #eff0f1;
   padding: 0 2.93333em;
   margin: 4.4em 0; }
   @media (min-width: 450px) {
@@ -1577,63 +1558,34 @@ aside {
   @media (min-width: 900px) {
     .search-pager__item {
       margin-right: 0.36667em; } }
-  .search-pager__item a {
-    transition: all 0.3s ease;
-    font-size: 0.9em;
-    line-height: 1.62963em;
-    font-weight: 700;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border: 0;
-    text-align: center;
-    padding: 0.36667em; }
-    @media (min-width: 450px) {
-      .search-pager__item a {
-        background-color: #0000ff;
-        color: #fff;
-        border-radius: 3px;
-        width: 2.2em;
-        height: 2.2em;
-        padding: 0; } }
-    @media (min-width: 900px) {
-      .search-pager__item a {
-        font-size: 0.8em;
-        line-height: 1.65em;
-        width: 1.76em;
-        height: 1.76em; } }
-    .search-pager__item a:hover, .search-pager__item a:active {
-      text-decoration: underline;
-      color: #fff;
-      background-color: #0000ff; }
-      @media (min-width: 450px) {
-        .search-pager__item a:hover, .search-pager__item a:active {
-          font-size: 1em;
-          line-height: 1.46667em;
-          background-color: navy; } }
-      .search-pager__item a:hover svg, .search-pager__item a:active svg {
-        fill: black; }
-    .search-pager__item a svg {
-      height: 1.3em;
-      fill: #fff;
-      display: block; }
-      @media (min-width: 450px) {
-        .search-pager__item a svg {
-          height: 1em; } }
-  .search-pager__item.is-active a {
-    font-size: 1em;
-    line-height: 1.46667em; }
-    @media (min-width: 450px) {
-      .search-pager__item.is-active a {
-        background-color: #737373;
-        color: #fff; }
-        .search-pager__item.is-active a:hover, .search-pager__item.is-active a:active {
-          background-color: black; } }
-  .search-pager__item.not-active {
+  .search-pager__item.is-active .search-pager__item-link {
+    font-weight: bold; }
+  .search-pager__item.not-active .search-pager__item-link {
     display: none; }
     @media (min-width: 450px) {
-      .search-pager__item.not-active {
+      .search-pager__item.not-active .search-pager__item-link {
         display: inline-block; } }
+
+.search-pager__item-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 0;
+  text-align: center;
+  padding: 0.36667em; }
+  .search-pager__item-link:hover, .search-pager__item-link:active {
+    text-decoration: underline; }
+    .search-pager__item-link:hover svg, .search-pager__item-link:active svg {
+      fill: black;
+      border-bottom: 1px solid #222; }
+  .search-pager__item-link svg {
+    height: 1.3em;
+    fill: #222;
+    display: block;
+    border-bottom: 1px solid transparent; }
+    @media (min-width: 450px) {
+      .search-pager__item-link svg {
+        height: 1em; } }
 
 /**
  * search-results-stat.scss
@@ -1642,8 +1594,6 @@ aside {
  * @copyright Copyright (c) 2017 Palantir.net
  */
 .search-results-stat {
-  font-size: 0.9em;
-  line-height: 1.62963em;
   color: #555; }
   .search-results-stat:focus {
     outline: 0; }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,6 +30,7 @@
 
 /* Component (SMACSS module) rules */
 @import "components/text-search/search-form";
+@import "components/text-search/autocomplete";
 @import "components/search-filters";
 @import "components/aside";
 @import "components/results/search-results";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,6 +1639,7 @@ class-utils@^0.3.5:
 classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@4.1.x:
   version "4.1.11"
@@ -2157,12 +2158,19 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
-define-properties@^1.0.1, define-properties@^1.1.2:
+define-properties@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -2330,6 +2338,7 @@ dom-urls@^1.1.0:
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -2469,6 +2478,18 @@ es-abstract@^1.10.0, es-abstract@^1.2.1, es-abstract@^1.4.3, es-abstract@^1.5.1,
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
+es-abstract@^1.5.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
 es-to-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
@@ -2476,6 +2497,15 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.42"
@@ -3227,9 +3257,10 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "^3.1.0"
 
-for-each@^0.3.2:
+for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
 
@@ -3246,6 +3277,7 @@ for-own@^0.1.4:
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -3336,6 +3368,7 @@ fstream@^1.0.0, fstream@^1.0.2:
 function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 function.prototype.name@^1.1.0:
   version "1.1.0"
@@ -3487,6 +3520,7 @@ global-prefix@^1.0.1:
 global@~4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  integrity sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
@@ -3631,6 +3665,7 @@ has-flag@^3.0.0:
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -3663,15 +3698,10 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
-  dependencies:
-    function-bind "^1.0.2"
-
-has@^1.0.2:
+has@^1.0.1, has@^1.0.2, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
 
@@ -3710,6 +3740,11 @@ hawk@~6.0.2:
 he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -4070,9 +4105,14 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
+is-callable@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-callable@^1.1.3, is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
 
 is-ci@^1.0.10:
   version "1.1.0"
@@ -4095,6 +4135,7 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -4163,6 +4204,7 @@ is-fullwidth-code-point@^2.0.0:
 is-function@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+  integrity sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -4286,6 +4328,7 @@ is-redirect@^1.0.0:
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
 
@@ -4314,6 +4357,13 @@ is-svg@^2.0.0:
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-touch-device@^1.0.1:
   version "1.0.1"
@@ -5239,6 +5289,7 @@ mimic-fn@^1.0.0:
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
 
@@ -5614,6 +5665,11 @@ object-assign@4.1.1, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+  integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
+
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -5630,9 +5686,14 @@ object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
 
-object-keys@^1.0.11, object-keys@^1.0.8:
+object-keys@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-keys@^1.0.12, object-keys@^1.0.8:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -5845,11 +5906,12 @@ parse-glob@^3.0.4:
     is-glob "^2.0.0"
 
 parse-headers@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.1.tgz#6ae83a7aa25a9d9b700acc28698cd1f1ed7e9536"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.2.tgz#9545e8a4c1ae5eaea7d24992bca890281ed26e34"
+  integrity sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==
   dependencies:
-    for-each "^0.3.2"
-    trim "0.0.1"
+    for-each "^0.3.3"
+    string.prototype.trim "^1.1.2"
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -6343,6 +6405,7 @@ process@^0.11.10:
 process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+  integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
 
 progress@^2.0.0:
   version "2.0.0"
@@ -6526,6 +6589,31 @@ react-animate-height@1.0.2:
   optionalDependencies:
     "@types/react" ">=15"
 
+react-aria-live@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-aria-live/-/react-aria-live-2.0.2.tgz#9cfc2352544275586f74b66d18c54a8b3b00398a"
+  integrity sha512-a94NMIidZMX+p+s2+UPTcE+fzl+68RYcdjs4GUDOTe7xV9W0w9fw223Me7E7+PSibwBHrlf6LaJLQBgyi+TbyQ==
+  dependencies:
+    uuid "^3.2.1"
+
+react-autosuggest@9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.4.3.tgz#eb46852422a48144ab9f39fb5470319222f26c7c"
+  integrity sha512-wFbp5QpgFQRfw9cwKvcgLR8theikOUkv8PFsuLYqI2PUgVlx186Cz8MYt5bLxculi+jxGGUUVt+h0esaBZZouw==
+  dependencies:
+    prop-types "^15.5.10"
+    react-autowhatever "^10.1.2"
+    shallow-equal "^1.0.0"
+
+react-autowhatever@^10.1.2:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.2.0.tgz#bdd07bf19ddf78acdb8ce7ae162ac13b646874ab"
+  integrity sha512-dqHH4uqiJldPMbL8hl/i2HV4E8FMTDEdVlOIbRqYnJi0kTpWseF9fJslk/KS9pGDnm80JkYzVI+nzFjnOG/u+g==
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
 react-dates@16.4.0:
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react-dates/-/react-dates-16.4.0.tgz#61dee21082758e14d89103974be769b653f33c45"
@@ -6590,6 +6678,13 @@ react-portal@^4.1.2:
   resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.1.5.tgz#6665d4d2a92d47d6f8b07a6529e26fc52d5cccde"
   dependencies:
     prop-types "^15.5.8"
+
+react-themeable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
+  integrity sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=
+  dependencies:
+    object-assign "^3.0.0"
 
 react-with-direction@1.3.0, react-with-direction@^1.1.0:
   version "1.3.0"
@@ -7093,6 +7188,11 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+section-iterator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
+  integrity sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -7205,6 +7305,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shallow-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.1.0.tgz#cc022f030dcba0d1c198abf658a3c6c744e171ca"
+  integrity sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -7305,7 +7410,7 @@ sockjs@0.3.18:
 
 "solr-faceted-search-react@https://github.com/palantirnet/solr-faceted-search-react":
   version "0.12.1"
-  resolved "https://github.com/palantirnet/solr-faceted-search-react#2df2db3ce3d0bd4781d19179217f53013f4f7c44"
+  resolved "https://github.com/palantirnet/solr-faceted-search-react#18f30924d689ffbdd36e7074630cf3bc637abeac"
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"
@@ -7541,6 +7646,15 @@ string.prototype.padstart@^3.0.0:
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.4.3"
+    function-bind "^1.0.2"
+
+string.prototype.trim@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  integrity sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
     function-bind "^1.0.2"
 
 string.prototype.trimleft@^2.0.0:
@@ -7858,10 +7972,6 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-
 "true-case-path@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.2.tgz#7ec91130924766c7f573be3020c34f8fdfd00d62"
@@ -8094,6 +8204,11 @@ uuid@^2.0.2:
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.2.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
@@ -8370,6 +8485,7 @@ xdg-basedir@^3.0.0:
 xhr@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.5.0.tgz#bed8d1676d5ca36108667692b74b316c496e49dd"
+  integrity sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==
   dependencies:
     global "~4.3.0"
     is-function "^1.0.1"
@@ -8387,6 +8503,7 @@ xregexp@^3.2.0:
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
- Removes opinionated default query field from search query (formerly `q=tm_rendered_item:<term>`)
- Adds autocomplete functionality
- Adds ability to hide filters / facets from the UI
- Maintains term facet state in the URL as qs param
- "Breaking" updates to CSS (cleans overly opinionated styles)
- Adds classes for more easier theming