### PR TITLE
Root 863 enable solr proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-with-direction": "1.3.0",
     "replace-x": "1.5.0",
     "singularitygs": "^1.7.0",
-    "solr-faceted-search-react": "https://github.com/palantirnet/solr-faceted-search-react"
+    "solr-faceted-search-react": "git://github.com/palantirnet/solr-faceted-search-react.git#root-863-enable-proxy-for-solr"
   },
   "scripts": {
     "theme-styles": "node-sass-chokidar ./theme/search_theme_override.scss ./public/css/search_theme_override.css --watch",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-with-direction": "1.3.0",
     "replace-x": "1.5.0",
     "singularitygs": "^1.7.0",
-    "solr-faceted-search-react": "git://github.com/palantirnet/solr-faceted-search-react.git#root-863-enable-proxy-for-solr"
+    "solr-faceted-search-react": "https://github.com/palantirnet/solr-faceted-search-react"
   },
   "scripts": {
     "theme-styles": "node-sass-chokidar ./theme/search_theme_override.scss ./public/css/search_theme_override.css --watch",

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -6,7 +6,8 @@
  * copy the contents of this file into ./.env.local.js.
  *
  * Required settings
- * - The solr backend url.
+ * - The flag indicating if you are using the proxy as the query url.
+ * - The solr query url.
  *
  * Optional settings
  * - The optional settings illustrate the default values, which are hard
@@ -17,10 +18,15 @@
  */
 
 module.exports = {
-  // REQUIRED: The default solr backend.
-  // Note: The URL will most likely contain `/select`,
-  // such as `http://example.local:8983/solr/collection1/select`
-  url: "<your-solr-backend>",
+  // REQUIRED: Whether or not the url provided is the solr proxy (default: FALSE, uses the proxy)
+  proxyIsDisabled: FALSE,
+  // REQUIRED: The url to where the query request should be made.
+  //    If using the Federated Search Demo site with the proxy, use:
+  //        http://d8.fs-demo.local/search-api-federated-solr/search
+  //    If not using the proxy, the proxy, set to your solr backend, use:
+  //        <host>:<port>/<path>/<core>/<requestHandler>
+  //        i.e. `http://example.local:8983/solr/drupal8/select`
+  url: "http://d8.fs-demo.local/search-api-federated-solr/search",
   // OPTIONAL: If the solr backend requires Basic Authentication, uncomment below and enter the username and password
   // in the btoa function as specified below. This should ONLY allow READ access, as it will be accessible client-side.
   // userpass: btoa("username:password"),
@@ -48,7 +54,8 @@ module.exports = {
   // ],
   // OPTIONAL: Provides config for adding autocomplete functionality to text search, defaults to false
   // autocomplete : {
-  //   url: <your-endpoint-for-autocomplete-results>, // required @todo document accepted types
+  //   proxyIsDisabled: FALSE, // REQUIRED: whether or not your url is set to the query solr directly (defaults to false),
+  //   url: <your-endpoint-for-autocomplete-results>, // REQUIRED: using the proxy is recommended but can also be set to a Drupal search view REST export, or if necessary, a Solr backend
   //   appendWildcard: false, // OPTIONAL: defaults to false, whether or not to append wildcard to query term
   //   suggestionRows: 5, // OPTIONAL: defaults to 5
   //   numChars: 2, // OPTIONAL: defaults to 2, number of characters *after* which autocomplete results should appear

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,9 @@ const searchFromQuerystring = (solrClient, options = {}) => {
 // Initialize the solr client + search app with settings.
 const init = (settings) => {
   const defaults = {
-    // The default solr backend must be assigned in ./.env.local.js and by the search app settings in the module.
+    // Whether or not we should be querying the solr backend directly.
+    proxyIsDisabled: false,
+    // The query request endpoint url must be assigned in ./.env.local.js and by the search app settings in the module.
     url: "",
     // The search fields and filterable facets.
     searchFields: [
@@ -90,8 +92,9 @@ const init = (settings) => {
     return searchField;
   });
 
-  // The client class
+  // The client class.
   const solrClient = new SolrClient({
+    proxyIsDisabled: options.proxyIsDisabled,
     url: options.url,
     userpass: options.userpass,
     searchFields: options.searchFields,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7410,7 +7410,7 @@ sockjs@0.3.18:
 
 "solr-faceted-search-react@git://github.com/palantirnet/solr-faceted-search-react.git#root-863-enable-proxy-for-solr":
   version "0.12.1"
-  resolved "git://github.com/palantirnet/solr-faceted-search-react.git#b9145642c521752ea4f3d34e6f0758ca28947a68"
+  resolved "git://github.com/palantirnet/solr-faceted-search-react.git#48e7279fd2186302aefdb35cfd00df6b6ccd1d8b"
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7408,9 +7408,9 @@ sockjs@0.3.18:
     faye-websocket "^0.10.0"
     uuid "^2.0.2"
 
-"solr-faceted-search-react@https://github.com/palantirnet/solr-faceted-search-react":
+"solr-faceted-search-react@git://github.com/palantirnet/solr-faceted-search-react.git#root-863-enable-proxy-for-solr":
   version "0.12.1"
-  resolved "https://github.com/palantirnet/solr-faceted-search-react#18f30924d689ffbdd36e7074630cf3bc637abeac"
+  resolved "git://github.com/palantirnet/solr-faceted-search-react.git#b9145642c521752ea4f3d34e6f0758ca28947a68"
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7408,9 +7408,9 @@ sockjs@0.3.18:
     faye-websocket "^0.10.0"
     uuid "^2.0.2"
 
-"solr-faceted-search-react@git://github.com/palantirnet/solr-faceted-search-react.git#root-863-enable-proxy-for-solr":
+"solr-faceted-search-react@https://github.com/palantirnet/solr-faceted-search-react":
   version "0.12.1"
-  resolved "git://github.com/palantirnet/solr-faceted-search-react.git#48e7279fd2186302aefdb35cfd00df6b6ccd1d8b"
+  resolved "https://github.com/palantirnet/solr-faceted-search-react#5315a3ebefcc084cf1abf39676b37e8f1b71f453"
   dependencies:
     classnames "^2.2.5"
     prop-types "^15.6.1"


### PR DESCRIPTION
Adds ability to use solr proxy for search.  See https://github.com/palantirnet/search_api_federated_solr/pull/79