### PR TITLE
umhs-28: default to canonical url in results

### DIFF
--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -25,27 +25,18 @@ class FederatedResult extends React.Component {
 
   // Pass both the mutivalue and the single value url as a backup.
   getCanonicalLink(urls, url) {
-    const { hostname } = this.props;
-
-    if (urls != null) {
-      // If one of our links matches the current site, use it.
-      for (let i = 0; i < urls.length; i++) {
-        const url = new URL(urls[i]);
-        if (url.hostname === hostname) {
-          return urls[i];
-        }
-      }
-      // Otherwise, use the first in the list, which is the canonical (or only).
+    // Use the canonical url as a first option
+    if (urls != null && Array.isArray(urls) && urls.length > 0) {
       return urls[0];
     }
-
+    // Fall back to the single url (which will be relative)
     if (url != null) {
       return url;
     }
 
     // If no valid urls are passed, return nothing. This will result in an
     // unlinked title, but at least it won't crash.
-    return [];
+    return '';
   }
 
   intersperse(arr, sep) {


### PR DESCRIPTION
This PR updates the logic in rendering a search result URL: it now defaults to using the canonical URL.