### PR TITLE
UMHS-28: use canonical url

### DIFF
--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -25,27 +25,19 @@ class FederatedResult extends React.Component {
 
   // Pass both the mutivalue and the single value url as a backup.
   getCanonicalLink(urls, url) {
-    const { hostname } = this.props;
-
-    if (urls != null) {
-      // If one of our links matches the current site, use it.
-      for (let i = 0; i < urls.length; i++) {
-        const url = new URL(urls[i]);
-        if (url.hostname === hostname) {
-          return urls[i];
-        }
-      }
-      // Otherwise, use the first in the list, which is the canonical (or only).
+    if (Array.isArray(urls) && urls.length) {
+      // Use the first in the list, which is the canonical (or only).
       return urls[0];
     }
 
+    // Fall back to single value url.
     if (url != null) {
       return url;
     }
 
     // If no valid urls are passed, return nothing. This will result in an
     // unlinked title, but at least it won't crash.
-    return [];
+    return '';
   }
 
   intersperse(arr, sep) {

--- a/src/components/results/result.js
+++ b/src/components/results/result.js
@@ -23,19 +23,49 @@ class FederatedResult extends React.Component {
     }
   }
 
-  // Pass both the mutivalue and the single value url as a backup.
-  getCanonicalLink(urls, url) {
-    if (Array.isArray(urls) && urls.length) {
-      // Use the first in the list, which is the canonical (or only).
-      return urls[0];
+  /**
+   * Returns the appropriate link for a given search result.
+   * 1. Use the canonical url if present.
+   * 2. Next, attempt to find a url from the current host.
+   * 3. Then, use the first url returned in the array of urls.
+   * 4. Fall back to the legacy url field.
+   * 5. Send an empty string if none of these options work.
+   *
+   * @param doc
+   *   Search result object
+   * @returns string
+   */
+  getCanonicalLink(doc) {
+    const { hostname } = this.props;
+
+    // 1. Use the canonical url as a first option
+    if (Object.hasOwnProperty.call(doc, 'ss_canonical_url') && doc.ss_canonical_url) {
+      return doc.ss_canonical_url;
     }
 
-    // Fall back to single value url.
-    if (url != null) {
-      return url;
+    // Use a url from the current host, if present.  Otherwise use the first Url.
+    if (Object.hasOwnProperty.call(doc, 'sm_urls') && Array.isArray(doc.sm_urls)) {
+      // Attempt to find a url from the current host.
+      const currentHostUrl = doc.sm_urls.find((item) => {
+        const url = new URL(item);
+        return url.hostname === hostname;
+      });
+
+      // 2. Use the url from the current host.
+      if (currentHostUrl) {
+        return currentHostUrl;
+      }
+
+      // 3. Use the first url.
+      return doc.sm_urls[0];
     }
 
-    // If no valid urls are passed, return nothing. This will result in an
+    // 4. Fall back to the single url (which will be relative)
+    if (Object.hasOwnProperty.call(doc, 'ss_url') && doc.ss_url) {
+      return doc.ss_url;
+    }
+
+    // 5. If no valid urls are passed, return nothing. This will result in an
     // unlinked title, but at least it won't crash.
     return '';
   }
@@ -82,7 +112,7 @@ class FederatedResult extends React.Component {
         }
         <div className="search-results__container--right">
           <span className="search-results__label">{doc.ss_federated_type}</span>
-          <h3 className="search-results__heading"><a className="search-results__heading-link" href={this.getCanonicalLink(doc.sm_urls, doc.ss_url)} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
+          <h3 className="search-results__heading"><a href={this.getCanonicalLink(doc)} dangerouslySetInnerHTML={{__html: doc.ss_federated_title}} /></h3>
           <div className="search-results__meta">
             <cite className="search-results__citation">{this.renderSitenameLinks(doc.sm_site_name, doc.sm_urls, doc.ss_site_name)}</cite>
             <span className="search-results__date">{this.dateFormat(doc.ds_federated_date)}</span>


### PR DESCRIPTION
Adds logic for determining search result url, respecting canonical url, to 2.x 