### PR TITLE
Improves logic in the default site name value to prevent duplicate values in the 'fq' param

### DIFF
--- a/src/components/list-facet/index.js
+++ b/src/components/list-facet/index.js
@@ -4,7 +4,6 @@ import cx from 'classnames';
 import AnimateHeight from 'react-animate-height';
 import helpers from '../../helpers';
 
-
 class FederatedListFacet extends React.Component {
 
   constructor(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ const searchFromQuerystring = (solrClient, options = {}) => {
     }
     // If restricted to the current site by configuration, enforce it here.
     // This rule only applies if site has not been selected by the user.
-    if (searchField.field === 'sm_site_name' && searchField.value === undefined && options.siteSearch !== undefined) {
+    if (options.siteSearch !== undefined && searchField.field === 'sm_site_name' && searchField.value === undefined && searchField.isHidden === false) {
       searchField.value = [options.siteSearch];
     }
   });


### PR DESCRIPTION
If you configure the site to mimic the report in https://www.drupal.org/project/search_api_federated_solr/issues/3082487#comment-13269125, then two `sm_site_name` values will be set in the `fq` element of the query.

This change removes that error.

To test, toggle these items in the `env.local.js` file into their 4 distinct options (both on, one on, both off).

```
siteSearch:
hiddenSearchFields: (sm_site_name hidden)
```