### PR TITLE
FS-23: Browser console errors from package updates

### DIFF
--- a/patches/react-autosuggest+9.4.3.patch
+++ b/patches/react-autosuggest+9.4.3.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/react-autosuggest/dist/Autosuggest.js b/node_modules/react-autosuggest/dist/Autosuggest.js
+index eaac8a7..8f21e5b 100644
+--- a/node_modules/react-autosuggest/dist/Autosuggest.js
++++ b/node_modules/react-autosuggest/dist/Autosuggest.js
+@@ -88,8 +88,8 @@ var Autosuggest = function (_Component) {
+       this.suggestionsContainer = this.autowhatever.itemsContainer;
+     }
+   }, {
+-    key: 'componentWillReceiveProps',
+-    value: function componentWillReceiveProps(nextProps) {
++    key: 'UNSAFE_componentWillReceiveProps',
++    value: function UNSAFE_componentWillReceiveProps(nextProps) {
+       if ((0, _arrays2.default)(nextProps.suggestions, this.props.suggestions)) {
+         if (nextProps.highlightFirstSuggestion && nextProps.suggestions.length > 0 && this.justPressedUpDown === false && this.justMouseEntered === false) {
+           this.highlightFirstSuggestion();
+diff --git a/node_modules/react-autosuggest/dist/standalone/autosuggest.js b/node_modules/react-autosuggest/dist/standalone/autosuggest.js
+index 02f7a55..8a74b2e 100644
+--- a/node_modules/react-autosuggest/dist/standalone/autosuggest.js
++++ b/node_modules/react-autosuggest/dist/standalone/autosuggest.js
+@@ -152,8 +152,8 @@ return /******/ (function(modules) { // webpackBootstrap
+ 	      this.suggestionsContainer = this.autowhatever.itemsContainer;
+ 	    }
+ 	  }, {
+-	    key: 'componentWillReceiveProps',
+-	    value: function componentWillReceiveProps(nextProps) {
++	    key: 'UNSAFE_componentWillReceiveProps',
++	    value: function UNSAFE_componentWillReceiveProps(nextProps) {
+ 	      if ((0, _arrays2.default)(nextProps.suggestions, this.props.suggestions)) {
+ 	        if (nextProps.highlightFirstSuggestion && nextProps.suggestions.length > 0 && this.justPressedUpDown === false && this.justMouseEntered === false) {
+ 	          this.highlightFirstSuggestion();
+@@ -2281,8 +2281,8 @@ return /******/ (function(modules) { // webpackBootstrap
+ 	      this.ensureHighlightedItemIsVisible();
+ 	    }
+ 	  }, {
+-	    key: 'componentWillReceiveProps',
+-	    value: function componentWillReceiveProps(nextProps) {
++	    key: 'UNSAFE_componentWillReceiveProps',
++	    value: function UNSAFE_componentWillReceiveProps(nextProps) {
+ 	      if (nextProps.items !== this.props.items) {
+ 	        this.setSectionsItems(nextProps);
+ 	      }

--- a/patches/react-dates+21.8.0.patch
+++ b/patches/react-dates+21.8.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-dates/lib/components/DateInput.js b/node_modules/react-dates/lib/components/DateInput.js
+index 2723010..5641060 100644
+--- a/node_modules/react-dates/lib/components/DateInput.js
++++ b/node_modules/react-dates/lib/components/DateInput.js
+@@ -129,7 +129,7 @@ function (_ref) {
+     });
+   };
+ 
+-  _proto.componentWillReceiveProps = function componentWillReceiveProps(nextProps) {
++  _proto.UNSAFE_componentWillReceiveProps = function UNSAFE_componentWillReceiveProps(nextProps) {
+     var dateString = this.state.dateString;
+ 
+     if (dateString && nextProps.displayValue) {

--- a/src/components/range-facet/index.js
+++ b/src/components/range-facet/index.js
@@ -44,7 +44,7 @@ class FederatedRangeFacet extends React.Component {
   }
 
   // See: https://reactjs.org/docs/react-component.html#the-component-lifecycle
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(nextProps) {
     // Clear component inputs when rangeFacet value transitions from populated->empty.
     if (this.props.value.length && !nextProps.value.length) {
       this.setState({

--- a/src/components/text-search/no-autocomplete.js
+++ b/src/components/text-search/no-autocomplete.js
@@ -19,7 +19,7 @@ class FederatedTextSearchNoAutocomplete extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(nextProps) {
     this.setState({
       value: nextProps.value,
     });

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -31,7 +31,7 @@ class FederatedTextSearchAsYouType extends React.Component {
     this.shouldRenderSuggestions = this.shouldRenderSuggestions.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       value: nextProps.suggestQuery && nextProps.suggestQuery.value
         ? nextProps.suggestQuery.value
@@ -342,14 +342,14 @@ FederatedTextSearchAsYouType.propTypes = {
       queryField: PropTypes.string,
       suggestionRows: PropTypes.number,
       numChars: PropTypes.number,
-      result: {
+      result: PropTypes.shape({
         titleText: PropTypes.string,
         showDirectionsText: PropTypes.bool,
-      },
-      term: {
+      }),
+      term: PropTypes.shape({
         titleText: PropTypes.string,
         showDirectionsText: PropTypes.bool,
-      },
+      }),
     }),
     PropTypes.bool,
   ]).isRequired,


### PR DESCRIPTION
## Ticket
[FS-23: Browser console errors from package updates](https://palantir.atlassian.net/browse/FS-23)

## Description
- Addressing browser console errors for `componentWillReceiveProps`
- I replaced two warnings coming from the federated search by using `componentDidUpdate` for following components:  
  - `FederatedRangeFacet` (when the date range facet is cleared)
  - `FederatedTextSearchNoAutocomplete` (applies when autocomplete is enabled in `.env.local.js`)

And used prefixed `UNSAFE_` for:
   - For `FederatedTextSearchAsYouType` component in federated search, I prefixed the lifecycle with a `UNSAFE_`, as updating the lifecycle to `componentDidUpdate` caused a fatal nesting error on render. We might need to open a new ticket to address this independently, there could additional work around this upgrade. There is a roadmap that will eventually drop support/usages of `componentWillReceiveProps` in React 17. I will need to dig into this separately as there could be additional work for updating `FederatedTextSearchAsYouType` (without appending `UNSAFE_`)

There are warnings coming from `react-dates` and `react-autosuggest`. These warning relates to Reacts update/new approach to implementing lifecycles. Seems like `componentWillReceiveProps` is being deprecated. The easiest way to suppress the warning is to prefix the lifecycle with a `UNSAFE_`. 

The packages that have not upgraded their code to React 16 stated it will be a breaking change for the package. These are:
- `react-dates` for the Start/End fields, the`DateInput` component has the `componentWillReceiveProps`  deprecated code.
    - See https://github.com/airbnb/react-dates/issues/1748#issuecomment-584771403 for more info on this.
- `react-autosuggest` for autosuggestion in the text box uses `componentWillReceiveProps`. 
    - https://github.com/moroshko/react-autosuggest/issues/695

Additionally, when enabling autocomplete, I got a breaking `checker function` error in the console. I added `PropTypes.shape{()}` to the `results` and `term` properties for `FederatedTextSearchAsYouType` component. 

For the packages using `componentWillReceiveProps`, we could roll a patch to add `UNSAFE_` prefixes? Let me know if that makes sense as a temporary stop gap. 

## Testing
- [ ] Pull down code
- [ ] Remove `nodes_modules`
- [ ] Ensure your `env.local.js` has `autocomplete` uncommented
- [ ] Run `yarn && yarn start`
- [ ] Perform searches, facet filtering on all the fields visible.
- [ ] ~Ensure you only see warnings from `DateInput` and `Autosuggest` packages (more in Description, above) about this warning.~ 
- [ ] ~Observe for any other warning, asides from `DateInput` and `Autosuggest` packages.~
