### PR TITLE
Application CSS conflicts with new namespace

### DIFF
--- a/src/components/current-query/_fs-applied-filters.scss
+++ b/src/components/current-query/_fs-applied-filters.scss
@@ -5,12 +5,12 @@
  * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
-.fs-applied-filters {
+#fs-root .fs-applied-filters {
   margin: rhythm(1) 0;
   display: block;
 }
 
-.fs-applied-filters__filter {
+#fs-root .fs-applied-filters__filter {
   @include adjust-font-size-to($label, .8);
   padding-bottom: rhythm(.2);
   border: 0;

--- a/src/components/current-query/index.js
+++ b/src/components/current-query/index.js
@@ -103,7 +103,8 @@ class RangeFacetType extends React.Component {
 class TextFacetType extends React.Component {
   removeTextValue(field) {
     this.props.announcePolite(`Removed search term ${field.value}.`);
-    this.props.onChange(field, '');
+    // Setting this to '' or "" throws a fatal error.
+    this.props.onChange(field, null);
     // Get current querystring params.
     const parsed = queryString.parse(window.location.search);
     // Remove the search term param, if it exists.

--- a/src/components/text-search/_fs-autocomplete.scss
+++ b/src/components/text-search/_fs-autocomplete.scss
@@ -22,7 +22,9 @@
   }
 }
 
-.fs-react-autosuggest {
+/** These classes are outside of Federated Search app namespace. **/
+
+.react-autosuggest {
   &__container {
     position: relative;
     flex: 1;

--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -193,23 +193,23 @@ class FederatedTextSearchAsYouType extends React.Component {
     const directionsText = mode === 'term' ? termShowDirectionsText : resultShowDirectionsText;
 
     const suggestionsWrapperClasses = directionsText
-      ? 'fs-react-autosuggest__suggestions-itemslist-wrapper fs-react-autosuggest__suggestions-itemslist-wrapper--with-directions'
-      : 'fs-react-autosuggest__suggestions-itemslist-wrapper';
+      ? 'react-autosuggest__suggestions-itemslist-wrapper react-autosuggest__suggestions-itemslist-wrapper--with-directions'
+      : 'react-autosuggest__suggestions-itemslist-wrapper';
 
     return (
       <div {... containerProps}>
-        <div className="fs-react-autosuggest__container-title">
+        <div className="react-autosuggest__container-title">
           {titleText}
-          <button className="fs-react-autosuggest__container-close-button" onClick={this.onSuggestionsClearRequested}>x</button>
+          <button className="react-autosuggest__container-close-button" onClick={this.onSuggestionsClearRequested}>x</button>
         </div>
         <div className={suggestionsWrapperClasses}>
           {children}
         </div>
         {/* @todo add logic for suggestion mode and alter directionsText accordingly */}
         {directionsText &&
-          <div className="fs-react-autosuggest__container-directions">
-            <span className="fs-react-autosuggest__container-directions-item">Press <code>ENTER</code> to search for <strong>{query}</strong> or <code>ESC</code> to close.</span>
-            <span className="fs-react-autosuggest__container-directions-item">Press ↑ and ↓ to highlight a suggestion then <code>ENTER</code> to be redirected to that suggestion.</span>
+          <div className="react-autosuggest__container-directions">
+            <span className="react-autosuggest__container-directions-item">Press <code>ENTER</code> to search for <strong>{query}</strong> or <code>ESC</code> to close.</span>
+            <span className="react-autosuggest__container-directions-item">Press ↑ and ↓ to highlight a suggestion then <code>ENTER</code> to be redirected to that suggestion.</span>
           </div>
         }
       </div>
@@ -256,7 +256,7 @@ class FederatedTextSearchAsYouType extends React.Component {
     // Render a link for search result suggestions.
     return (
       <a
-        className="fs-react-autosuggest__suggestion-link"
+        className="react-autosuggest__suggestion-link"
         href={suggestion.sm_urls[0]}
       >
         {highlightedTitle}
@@ -284,7 +284,7 @@ class FederatedTextSearchAsYouType extends React.Component {
       type: 'search',
       name: 'search',
       id: 'search',
-      className: 'fs-react-autosuggest__input',
+      className: 'react-autosuggest__input',
       onChange: this.onChange,
       onKeyDown: this.handleInputKeyDown,
       value: value || '',

--- a/src/styles.css
+++ b/src/styles.css
@@ -678,11 +678,12 @@
   .fs-search-form__autocomplete-container .fs-search-form__input-wrapper {
     width: 100%; }
 
-.fs-react-autosuggest__container {
+/** These classes are outside of Federated Search app namespace. **/
+.react-autosuggest__container {
   position: relative;
   flex: 1; }
 
-.fs-react-autosuggest__input {
+.react-autosuggest__input {
   font-size: 0.8em;
   line-height: 1.46667em;
   flex: 1;
@@ -691,18 +692,17 @@
   border-bottom-left-radius: 4px;
   height: 34px;
   padding: .5rem; }
-  .fs-react-autosuggest__input:focus {
+  .react-autosuggest__input:focus {
     border-color: #333;
     outline: none; }
-  .react-autosuggest__container--open .fs-react-autosuggest__input {
+  .react-autosuggest__container--open .react-autosuggest__input {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0; }
 
-/* This namespace is outside our control */
 .react-autosuggest__suggestions-container {
   display: none; }
 
-.fs-react-autosuggest__container-title {
+.react-autosuggest__container-title {
   font-size: 0.8em;
   line-height: 1.46667em;
   position: relative;
@@ -710,7 +710,7 @@
   padding: 10px 20px;
   border-bottom: 1px dashed #ccc; }
 
-.fs-react-autosuggest__container-close-button {
+.react-autosuggest__container-close-button {
   font-size: 0.8em;
   line-height: 1.46667em;
   font-style: normal;
@@ -720,18 +720,18 @@
   cursor: pointer;
   position: absolute;
   right: 5px; }
-  .fs-react-autosuggest__container-close-button:hover {
+  .react-autosuggest__container-close-button:hover {
     border-color: #b5b5b5;
     background-color: #f6f6f6; }
 
-.fs-react-autosuggest__container-directions {
+.react-autosuggest__container-directions {
   padding: 10px 20px; }
-  .fs-react-autosuggest__container-directions-item {
+  .react-autosuggest__container-directions-item {
     font-size: 0.8em;
     line-height: 1.46667em;
     display: block; }
 
-.fs-react-autosuggest__suggestions-container--open {
+.react-autosuggest__suggestions-container--open {
   display: block;
   position: absolute;
   top: 33px;
@@ -742,17 +742,17 @@
   border-bottom-right-radius: 4px;
   z-index: 2; }
 
-.fs-react-autosuggest__suggestions-itemslist-wrapper--with-directions .react-autosuggest__suggestion:last-child {
+.react-autosuggest__suggestions-itemslist-wrapper--with-directions .react-autosuggest__suggestion:last-child {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   border-bottom-color: #ccc; }
 
-.fs-react-autosuggest__suggestions-list {
+.react-autosuggest__suggestions-list {
   margin: 0;
   padding: 0;
   list-style-type: none; }
 
-.fs-react-autosuggest__suggestion {
+.react-autosuggest__suggestion {
   font-size: 0.8em;
   line-height: 1.46667em;
   cursor: pointer;
@@ -760,15 +760,15 @@
   background-color: #fff;
   border: 1px solid #fff;
   border-bottom-color: #ccc; }
-  .fs-react-autosuggest__suggestion:last-child {
+  .react-autosuggest__suggestion:last-child {
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     border-bottom-color: #fff; }
 
-.fs-react-autosuggest__suggestion-link {
+.react-autosuggest__suggestion-link {
   color: #737373; }
 
-.fs-react-autosuggest__suggestion--highlighted {
+.react-autosuggest__suggestion--highlighted {
   background-color: #f6f6f6;
   border: 1px solid #f6f6f6;
   border-bottom-color: #ccc; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -698,7 +698,8 @@
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0; }
 
-.fs-react-autosuggest__suggestions-container {
+/* This namespace is outside our control */
+.react-autosuggest__suggestions-container {
   display: none; }
 
 .fs-react-autosuggest__container-title {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1180,11 +1180,11 @@ aside.fs-aside {
  *
  * @copyright Copyright (c) 2017-2019 Palantir.net
  */
-.fs-applied-filters {
+#fs-root .fs-applied-filters {
   margin: 1.46667em 0;
   display: block; }
 
-.fs-applied-filters__filter {
+#fs-root .fs-applied-filters__filter {
   font-size: 0.8em;
   line-height: 1.46667em;
   padding-bottom: 0.29333em;
@@ -1194,7 +1194,7 @@ aside.fs-aside {
   margin-bottom: 0.73333em;
   display: inline-block;
   cursor: pointer; }
-  .fs-applied-filters__filter:after {
+  #fs-root .fs-applied-filters__filter:after {
     font-size: 1.2em;
     line-height: 1.22222em;
     content: "\D7";


### PR DESCRIPTION
So when I merged in all of our work, the application broke. 

Part of it is namespacing on the autocomplete CSS, which I have marked here.

But now I get an error after clearing the search term.

```
TypeError: state is not iterable
setSuggestQueryField
node_modules/solr-faceted-search-react/src/reducers/suggestQuery.js:12
   9 | const setSuggestQueryField = (state, action) => {
  10 |   // Clear the suggestQueryField data only if the search field has been cleared.
  11 |   if (action.newFields.filter(field => field.field === "tm_rendered_item" && field.value ==="").length) {
> 12 |     return Object.assign({},
  13 |       ...state,
  14 |       {
  15 |         suggestQuery: {
```

There is also a build notice about HTML accessibility, viewable on `yarn start`:

```
Line 27:9:   The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid
```
