### PR TITLE
WIP: reset value properly onchange.

### DIFF
--- a/src/components/text-search/search-as-you-type.js
+++ b/src/components/text-search/search-as-you-type.js
@@ -32,12 +32,25 @@ class FederatedTextSearchAsYouType extends React.Component {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState({
-      value: nextProps.suggestQuery && nextProps.suggestQuery.value
-        ? nextProps.suggestQuery.value
-        : nextProps.value,
-      suggestions: nextProps.suggestions ? nextProps.suggestions.docs : this.state.suggestions,
-    });
+    // nextProps.value will be null if the filter is reset.
+    //console.log(nextProps)
+    console.log(nextProps.value)
+    console.log(nextProps.suggestQuery.value)
+    console.log(this.state)
+    if (nextProps.value === null && nextProps.suggestQuery.value !== nextProps.value) {
+      this.setState({
+        value: "",
+        suggestions: [],
+      });
+    }
+    else {
+      this.setState({
+        value: nextProps.suggestQuery && nextProps.suggestQuery.value
+          ? nextProps.suggestQuery.value
+          : nextProps.value,
+          suggestions: nextProps.suggestions ? nextProps.suggestions.docs : this.state.suggestions,
+        });
+    }
   }
 
   /**


### PR DESCRIPTION
Trying to handle the following use-case:

* Enable autocomplete
* Type "terrier" and hit the search button
* Remove the "terrier" filter with the X

*Note: Before this change, this behavior does not occur if you load the page with the URL string set (e.g. load http://localhost:3000/?search=terrier).

What should happen:

* The search term should be removed from the search box.
* You can then search for another term.

What does happen:

* The search term is removed from the search box.
* Trying to search for another term resets after 3 characters are entered.
