### PR TITLE
FS-9 Mess around with layout (proof of concept)

### DIFF
--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -46,6 +46,20 @@ module.exports = {
   pageTitle: null,
   // OPTIONAL: The hostname to emulate when testing.
   hostname: "example.local",
+  layoutAndClasses : {
+    // OPTIONAL: Specify the column widths.
+    gridTemplateColumns: "33% 66%",
+    // OPTIONAL: Add custom classes.
+    containerClass: "custom-container",
+    asideClass: "custom-aside",
+    mainClass: "custom-main",
+    // OPTIONAl: Reverse desktop column order.
+    reverseDesktopColumns: false,
+    // OPTIONAL: Reverse mobile stack order.
+    reverseMobileOrder: false,
+    // Breakpoint for Desktop. Layout will change when wider then the value specifed.
+    breakpointDesktop: 900,
+  },
   // OPTIONAL: Machine name of those search fields whose facets/filter and current values should be hidden in UI.
   // Note: if their values are pre-set (i.e. sent in qs to app), they will still be sent in the query.
   // hiddenSearchFields: [ // Defaults to [];

--- a/src/components/_fs-aside.scss
+++ b/src/components/_fs-aside.scss
@@ -6,15 +6,7 @@
  */
 
 .fs-aside {
-  width: 22.85714%;
-  float: left;
-  margin-right: -100%;
-  margin-left: 0;
-  clear: both;
-  margin-bottom: rhythm(1);
   background-color: $c-bg-gray;
-
   @include breakpoint($bp2) {
-    padding-top: rhythm(1);
   }
 }

--- a/src/components/_fs-aside.scss
+++ b/src/components/_fs-aside.scss
@@ -10,3 +10,14 @@
   @include breakpoint($bp2) {
   }
 }
+
+.fs-aside__mobile-reverse {
+  order: 2;
+}
+
+// Layout option to move aside to right on desktop
+.fs-aside__desktop-reverse {
+  @include breakpoint($bp2) {
+    order: 6; // Should be higher than all mobile orders.
+  }
+}

--- a/src/components/_fs-aside.scss
+++ b/src/components/_fs-aside.scss
@@ -8,10 +8,6 @@
 .fs-aside {
   margin-left: 0;
   margin-bottom: rhythm(1);
-  background-color: $c-bg-gray;
-  @include breakpoint($bp2) {
-    padding-top: rhythm(1);
-  }
 }
 
 .fs-aside__mobile-reverse {

--- a/src/components/_fs-container.scss
+++ b/src/components/_fs-container.scss
@@ -8,9 +8,18 @@
 .fs-container {
   display: flex;
   flex-direction: column;
+  width: 100%;
+  min-width: 260px;
+  padding: 0 1.46667em;
+  margin: 0 auto;
   @include breakpoint($bp2) {
     display: grid;
-    grid-column-gap: 1em;
+    grid-column-gap: 5%;
     grid-template-columns: 33% 66%;
+    width: 90%;
+    padding: 0;
+  }
+  @include breakpoint($bp2) {
+    max-width: 1400px;
   }
 }

--- a/src/components/_fs-container.scss
+++ b/src/components/_fs-container.scss
@@ -15,8 +15,8 @@
   margin: 0 auto;
   @include breakpoint($bp2) {
     display: grid;
-    grid-column-gap: 5%;
-    grid-template-columns: 33% 66%;
+    grid-column-gap: 0;
+    grid-template-columns: 25% 75%;
     width: 90%;
     padding: 0;
   }

--- a/src/components/_fs-container.scss
+++ b/src/components/_fs-container.scss
@@ -16,7 +16,7 @@
   @include breakpoint($bp2) {
     display: grid;
     grid-column-gap: 0;
-    grid-template-columns: 25% 75%;
+    grid-template-columns: 22.85714% 74.28571%;
     width: 90%;
     padding: 0;
   }

--- a/src/components/_fs-container.scss
+++ b/src/components/_fs-container.scss
@@ -6,6 +6,8 @@
  */
 
 .fs-container {
+  display: flex;
+  flex-direction: column;
   @include breakpoint($bp2) {
     display: grid;
     grid-column-gap: 1em;

--- a/src/components/_fs-container.scss
+++ b/src/components/_fs-container.scss
@@ -1,0 +1,14 @@
+/**
+ * container.scss
+ * Define container styles.
+ *
+ * @copyright Copyright (c) 2017-2020 Palantir.net
+ */
+
+.fs-container {
+  @include breakpoint($bp2) {
+    display: grid;
+    grid-column-gap: 1em;
+    grid-template-columns: 33% 66%;
+  }
+}

--- a/src/components/_fs-container.scss
+++ b/src/components/_fs-container.scss
@@ -6,6 +6,7 @@
  */
 
 .fs-container {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/src/components/_fs-main.scss
+++ b/src/components/_fs-main.scss
@@ -10,7 +10,7 @@
   margin-right: 0;
   margin-bottom: rhythm(1);
   @include breakpoint($bp2) {
-    padding-left: 7.5%; //Default to match previous version padding.
+    padding-left: 3.703713%; //Default to match previous version 1.x padding.
   }
   &.fs-main__has-custom-columns {
     @include breakpoint($bp2) {

--- a/src/components/_fs-main.scss
+++ b/src/components/_fs-main.scss
@@ -6,14 +6,6 @@
  */
 
 .fs-main {
-  width: 74.28571%;
-  float: right;
-  margin-left: 0;
-  margin-right: 0;
-  clear: none;
-  margin-bottom: rhythm(1);
-
   @include breakpoint($bp2) {
-    padding-top: rhythm(1);
   }
 }

--- a/src/components/_fs-main.scss
+++ b/src/components/_fs-main.scss
@@ -7,5 +7,18 @@
 
 .fs-main {
   @include breakpoint($bp2) {
+    padding-left: 7.5%; //Default to match previous version padding.
+  }
+  &.fs-main__has-custom-columns {
+    @include breakpoint($bp2) {
+      padding-left: 2em;
+    }
+  }
+}
+
+.fs-main__desktop-reverse {
+  @include breakpoint($bp2) {
+    padding-left: 0;
+    padding-right: 2em;
   }
 }

--- a/src/components/_fs-search-filters.scss
+++ b/src/components/_fs-search-filters.scss
@@ -215,6 +215,7 @@
 }
 
 .fs-search-accordion__title {
+  margin: 0;
   @extend %h2;
   border-bottom: solid 1px $gray-light;
   padding-top: rhythm(.75);

--- a/src/components/_fs-search-filters.scss
+++ b/src/components/_fs-search-filters.scss
@@ -5,6 +5,13 @@
  * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 
+.fs-search-filters {
+  background-color: $c-bg-gray;
+  @include breakpoint($bp2) {
+    padding-top: rhythm(1);
+  }
+}
+
 .fs-search-filters__trigger,
 .fs-search-accordion__title {
   @include adjust-font-size-to($sm-heading, 1);

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -106,6 +106,7 @@ class FederatedSolrFacetedSearch extends React.Component {
               bootstrapCss={bootstrapCss}
               onNewSearch={this.resetFilters}
               resultsCount={this.props.results.numFound}
+              options={this.props.options}
             >
               {/* Only render the visible facets / filters.
                   Note: their values may still be used in the query, if they were pre-set. */}

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -101,7 +101,7 @@ class FederatedSolrFacetedSearch extends React.Component {
     return (
       <LiveAnnouncer>
         <div className={`fs-container ${this.props.options.layoutAndClasses.containerClass}`} style={{ gridTemplateColumns: this.props.options.layoutAndClasses.layout }}>
-          <aside className={`fs-aside ${this.props.options.layoutAndClasses.asideClass}`}>
+          <aside className={`fs-aside ${this.props.options.layoutAndClasses.asideClass} ${this.props.options.layoutAndClasses.reverseDesktopColumns ? "fs-aside__desktop-reverse" : ""} ${this.props.options.layoutAndClasses.reverseMobileOrder ? "fs-aside__mobile-reverse" : ""}`}>
             <SearchFieldContainerComponent
               bootstrapCss={bootstrapCss}
               onNewSearch={this.resetFilters}

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -100,12 +100,12 @@ class FederatedSolrFacetedSearch extends React.Component {
 
     // Grab env vars.
     const {
-      containerClass='',
-      asideClass='',
-      mainClass='',
-      gridTemplateColumns='',
-      reverseDesktopColumns='',
-      reverseMobileOrder=''
+      containerClass = '',
+      asideClass = '',
+      mainClass = '',
+      gridTemplateColumns = '',
+      reverseDesktopColumns = '',
+      reverseMobileOrder = '',
     } = this.props.options.layoutAndClasses || {};
 
     return (

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -98,10 +98,17 @@ class FederatedSolrFacetedSearch extends React.Component {
       pageTitle = <h1>{this.props.options.pageTitle}</h1>;
     }
 
+    // Grab env vars.
+    const containerClass = this.props.options.layoutAndClasses.containerClass || null;
+    const asideClass = this.props.options.layoutAndClasses.asideClass || null;
+    const gridTemplateColumns = this.props.options.layoutAndClasses.layout || null;
+    const reverseDesktopColumns = this.props.options.layoutAndClasses.reverseDesktopColumns ? 'fs-aside__desktop-reverse' : '';
+    const reverseMobileOrder = this.props.options.layoutAndClasses.reverseMobileOrder ? 'fs-aside__mobile-reverse' : '';
+
     return (
       <LiveAnnouncer>
-        <div className={`fs-container ${this.props.options.layoutAndClasses.containerClass}`} style={{ gridTemplateColumns: this.props.options.layoutAndClasses.layout }}>
-          <aside className={`fs-aside ${this.props.options.layoutAndClasses.asideClass} ${this.props.options.layoutAndClasses.reverseDesktopColumns ? "fs-aside__desktop-reverse" : ""} ${this.props.options.layoutAndClasses.reverseMobileOrder ? "fs-aside__mobile-reverse" : ""}`}>
+        <div className={`fs-container ${containerClass}`} style={{ gridTemplateColumns: gridTemplateColumns }}>
+          <aside className={`fs-aside ${asideClass} ${reverseDesktopColumns} ${reverseMobileOrder}`}>
             <SearchFieldContainerComponent
               bootstrapCss={bootstrapCss}
               onNewSearch={this.resetFilters}

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -100,8 +100,8 @@ class FederatedSolrFacetedSearch extends React.Component {
 
     return (
       <LiveAnnouncer>
-        <div className="fs-container">
-          <aside className="fs-aside">
+        <div className={`fs-container ${this.props.options.layoutAndClasses.containerClass}`} style={{ gridTemplateColumns: this.props.options.layoutAndClasses.layout }}>
+          <aside className={`fs-aside ${this.props.options.layoutAndClasses.asideClass}`}>
             <SearchFieldContainerComponent
               bootstrapCss={bootstrapCss}
               onNewSearch={this.resetFilters}
@@ -137,7 +137,7 @@ class FederatedSolrFacetedSearch extends React.Component {
               }
             </SearchFieldContainerComponent>
           </aside>
-          <div className="fs-main">
+          <div className={`fs-main ${this.props.options.layoutAndClasses.mainClass}`}>
             {pageTitle}
             <div className="fs-search-form" autoComplete="on">
               <FederatedTextSearch

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -103,7 +103,7 @@ class FederatedSolrFacetedSearch extends React.Component {
       containerClass = '',
       asideClass = '',
       mainClass = '',
-      gridTemplateColumns = '22.85714% 74.28571%',
+      gridTemplateColumns = '',
       reverseDesktopColumns = false,
       reverseMobileOrder = false,
     } = this.props.options.layoutAndClasses || {};
@@ -148,7 +148,7 @@ class FederatedSolrFacetedSearch extends React.Component {
               }
             </SearchFieldContainerComponent>
           </aside>
-          <div className={`fs-main ${mainClass}`}>
+          <div className={`fs-main ${mainClass} ${reverseDesktopColumns ? 'fs-main__desktop-reverse' : ''} ${reverseMobileOrder ? 'fs-main__mobile-reverse' : ''} ${gridTemplateColumns ? 'fs-main__has-custom-columns' : ''}`}>
             {pageTitle}
             <div className="fs-search-form" autoComplete="on">
               <FederatedTextSearch

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -99,11 +99,14 @@ class FederatedSolrFacetedSearch extends React.Component {
     }
 
     // Grab env vars.
-    const containerClass = this.props.options.layoutAndClasses.containerClass || null;
-    const asideClass = this.props.options.layoutAndClasses.asideClass || null;
-    const gridTemplateColumns = this.props.options.layoutAndClasses.layout || null;
-    const reverseDesktopColumns = this.props.options.layoutAndClasses.reverseDesktopColumns ? 'fs-aside__desktop-reverse' : '';
-    const reverseMobileOrder = this.props.options.layoutAndClasses.reverseMobileOrder ? 'fs-aside__mobile-reverse' : '';
+    const {
+      containerClass='',
+      asideClass='',
+      mainClass='',
+      gridTemplateColumns='',
+      reverseDesktopColumns='',
+      reverseMobileOrder=''
+    } = this.props.options.layoutAndClasses || {};
 
     return (
       <LiveAnnouncer>
@@ -145,7 +148,7 @@ class FederatedSolrFacetedSearch extends React.Component {
               }
             </SearchFieldContainerComponent>
           </aside>
-          <div className={`fs-main ${this.props.options.layoutAndClasses.mainClass}`}>
+          <div className={`fs-main ${mainClass}`}>
             {pageTitle}
             <div className="fs-search-form" autoComplete="on">
               <FederatedTextSearch

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -104,14 +104,14 @@ class FederatedSolrFacetedSearch extends React.Component {
       asideClass = '',
       mainClass = '',
       gridTemplateColumns = '',
-      reverseDesktopColumns = '',
-      reverseMobileOrder = '',
+      reverseDesktopColumns = false,
+      reverseMobileOrder = false,
     } = this.props.options.layoutAndClasses || {};
 
     return (
       <LiveAnnouncer>
         <div className={`fs-container ${containerClass}`} style={{ gridTemplateColumns: gridTemplateColumns }}>
-          <aside className={`fs-aside ${asideClass} ${reverseDesktopColumns} ${reverseMobileOrder}`}>
+          <aside className={`fs-aside ${asideClass} ${reverseDesktopColumns ? 'fs-aside__desktop-reverse' : ''} ${reverseMobileOrder ? 'fs-aside__mobile-reverse' : ''}`}>
             <SearchFieldContainerComponent
               bootstrapCss={bootstrapCss}
               onNewSearch={this.resetFilters}

--- a/src/components/federated-solr-faceted-search.js
+++ b/src/components/federated-solr-faceted-search.js
@@ -103,7 +103,7 @@ class FederatedSolrFacetedSearch extends React.Component {
       containerClass = '',
       asideClass = '',
       mainClass = '',
-      gridTemplateColumns = '',
+      gridTemplateColumns = '22.85714% 74.28571%',
       reverseDesktopColumns = false,
       reverseMobileOrder = false,
     } = this.props.options.layoutAndClasses || {};

--- a/src/components/search-field-container.js
+++ b/src/components/search-field-container.js
@@ -11,9 +11,12 @@ class FederatedSearchFieldContainer extends React.Component {
     // This will return the width of the viewport.
     let intFrameWidth = window.innerWidth;
 
+    // Get our breakpoint option from env.
+    const breakpointDesktop = this.props.options.layoutAndClasses.breakpointDesktop || 900;
+
     this.state = {
       // Filters are visible for large / hidden for small screens by default.
-      expanded: intFrameWidth > 900,
+      expanded: intFrameWidth > breakpointDesktop,
     };
 
     this.handleClick = this.handleClick.bind(this);
@@ -22,7 +25,7 @@ class FederatedSearchFieldContainer extends React.Component {
       // Desktop height.
       let height = 'auto';
       // In mobile view, when resized, lets close things.
-      if (window.innerWidth < 900) {
+      if (window.innerWidth < breakpointDesktop) {
         height = 0;
       }
       this.setState({
@@ -78,6 +81,7 @@ class FederatedSearchFieldContainer extends React.Component {
 FederatedSearchFieldContainer.propTypes = {
   children: PropTypes.array,
   onNewSearch: PropTypes.func,
+  options: PropTypes.object,
 };
 
 export default FederatedSearchFieldContainer;

--- a/src/components/search-field-container.js
+++ b/src/components/search-field-container.js
@@ -12,7 +12,7 @@ class FederatedSearchFieldContainer extends React.Component {
     let intFrameWidth = window.innerWidth;
 
     // Get our breakpoint option from env.
-    const {breakpointDesktop='900'} = this.props.options.layoutAndClasses || {};
+    const { breakpointDesktop = '900' } = this.props.options.layoutAndClasses || {};
 
     this.state = {
       // Filters are visible for large / hidden for small screens by default.

--- a/src/components/search-field-container.js
+++ b/src/components/search-field-container.js
@@ -12,7 +12,7 @@ class FederatedSearchFieldContainer extends React.Component {
     let intFrameWidth = window.innerWidth;
 
     // Get our breakpoint option from env.
-    const breakpointDesktop = this.props.options.layoutAndClasses.breakpointDesktop || 900;
+    const {breakpointDesktop='900'} = this.props.options.layoutAndClasses || {};
 
     this.state = {
       // Filters are visible for large / hidden for small screens by default.

--- a/src/components/search-field-container.js
+++ b/src/components/search-field-container.js
@@ -9,7 +9,7 @@ class FederatedSearchFieldContainer extends React.Component {
     super(props);
 
     // This will return the width of the viewport.
-    const intFrameWidth = window.innerWidth;
+    let intFrameWidth = window.innerWidth;
 
     this.state = {
       // Filters are visible for large / hidden for small screens by default.
@@ -17,6 +17,18 @@ class FederatedSearchFieldContainer extends React.Component {
     };
 
     this.handleClick = this.handleClick.bind(this);
+
+    window.addEventListener('resize', () => {
+      // Desktop height.
+      let height = 'auto';
+      // In mobile view, when resized, lets close things.
+      if (window.innerWidth < 900) {
+        height = 0;
+      }
+      this.setState({
+        expanded: height,
+      });
+    });
   }
 
   handleClick() {

--- a/src/components/sort-menu/_fs-search-scope.scss
+++ b/src/components/sort-menu/_fs-search-scope.scss
@@ -10,6 +10,70 @@
   margin: rhythm(1) 0;
 }
 
+.fs-search-scope__filter {
+  width: 48.57143%;
+  clear: right;
+  float: left;
+  margin-left: 0;
+  margin-right: 2.85714%;
+
+  @include breakpoint($bp1) {
+    width: 31.42857%;
+    clear: right;
+    float: left;
+    margin-left: 0;
+    margin-right: 2.85714%;
+  }
+
+  &:nth-of-type(3n+1) {
+    width: 48.57143%;
+    clear: right;
+    float: left;
+    margin-left: 0;
+    margin-right: 2.85714%;
+    clear: both;
+
+    @include breakpoint($bp1) {
+      width: 31.42857%;
+      float: left;
+      margin-right: -100%;
+      margin-left: 0;
+      clear: both;
+    }
+  }
+
+  &:nth-of-type(3n+2) {
+    width: 48.57143%;
+    clear: right;
+    float: right;
+    margin-right: 0;
+
+    @include breakpoint($bp1) {
+      width: 31.42857%;
+      float: left;
+      margin-right: -100%;
+      margin-left: 34.28571%;
+      clear: none;
+    }
+  }
+
+  &:nth-of-type(3n+3) {
+    width: 48.57143%;
+    clear: right;
+    float: left;
+    margin-left: 0;
+    margin-right: 2.85714%;
+    clear: both;
+
+    @include breakpoint($bp1) {
+      width: 31.42857%;
+      float: right;
+      margin-left: 0;
+      margin-right: 0;
+      clear: none;
+    }
+  }
+}
 .fs-search-scope__select {
   @extend %select;
   @include adjust-font-size-to($label, .8);

--- a/src/components/text-search/_fs-autocomplete.scss
+++ b/src/components/text-search/_fs-autocomplete.scss
@@ -8,6 +8,17 @@
 
 .fs-search-form__autocomplete-container {
   display: flex;
+  @include breakpoint($bp1) {
+    width: 75%;
+  }
+
+  @include breakpoint($bp3) {
+    width: 50%;
+  }
+
+  .fs-search-form__input-wrapper {
+    width: 100%;
+  }
 }
 
 /** These classes are outside of Federated Search app namespace. **/

--- a/src/components/text-search/_fs-search-form.scss
+++ b/src/components/text-search/_fs-search-form.scss
@@ -21,6 +21,13 @@
   border-radius: 3px;
   display: flex;
   justify-content: space-between;
+  @include breakpoint($bp1) {
+    width: 75%;
+  }
+
+  @include breakpoint($bp3) {
+    width: 50%;
+  }
 }
 
 .fs-search-form__input {

--- a/src/styles.css
+++ b/src/styles.css
@@ -556,7 +556,7 @@
     .fs-container {
       display: grid;
       grid-column-gap: 0;
-      grid-template-columns: 25% 75%;
+      grid-template-columns: 22.85714% 74.28571%;
       width: 90%;
       padding: 0; } }
   @media (min-width: 900px) {
@@ -596,7 +596,7 @@
   margin-bottom: 1.46667em; }
   @media (min-width: 900px) {
     .fs-main {
-      padding-left: 7.5%; } }
+      padding-left: 3.703713%; } }
   @media (min-width: 900px) {
     .fs-main.fs-main__has-custom-columns {
       padding-left: 2em; } }

--- a/src/styles.css
+++ b/src/styles.css
@@ -377,6 +377,12 @@
  *
  * @copyright Copyright (c) 2017-2019 Palantir.net
  */
+.fs-search-filters {
+  background-color: #f6f6f6; }
+  @media (min-width: 900px) {
+    .fs-search-filters {
+      padding-top: 1.46667em; } }
+
 .fs-search-filters__trigger,
 .fs-search-accordion__title {
   font-size: 1em;
@@ -571,11 +577,7 @@
  */
 .fs-aside {
   margin-left: 0;
-  margin-bottom: 1.46667em;
-  background-color: #f6f6f6; }
-  @media (min-width: 900px) {
-    .fs-aside {
-      padding-top: 1.46667em; } }
+  margin-bottom: 1.46667em; }
 
 .fs-aside__mobile-reverse {
   order: 2; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -527,6 +527,7 @@
   margin: 0 0 0 0.73333em; }
 
 .fs-search-accordion__title {
+  margin: 0;
   border-bottom: solid 1px #e5e5e5;
   padding-top: 1.1em;
   padding-bottom: 1.1em; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -530,11 +530,14 @@
  *
  * @copyright Copyright (c) 2017-2020 Palantir.net
  */
-@media (min-width: 900px) {
-  .fs-container {
-    display: grid;
-    grid-column-gap: 1em;
-    grid-template-columns: 33% 66%; } }
+.fs-container {
+  display: flex;
+  flex-direction: column; }
+  @media (min-width: 900px) {
+    .fs-container {
+      display: grid;
+      grid-column-gap: 1em;
+      grid-template-columns: 33% 66%; } }
 
 /**
  * aside.scss
@@ -544,6 +547,13 @@
  */
 .fs-aside {
   background-color: #f6f6f6; }
+
+.fs-aside__mobile-reverse {
+  order: 2; }
+
+@media (min-width: 900px) {
+  .fs-aside__desktop-reverse {
+    order: 6; } }
 
 /**
  * aside.scss

--- a/src/styles.css
+++ b/src/styles.css
@@ -208,6 +208,12 @@
   border-radius: 3px;
   display: flex;
   justify-content: space-between; }
+  @media (min-width: 600px) {
+    .fs-search-form__input-wrapper {
+      width: 75%; } }
+  @media (min-width: 1100px) {
+    .fs-search-form__input-wrapper {
+      width: 50%; } }
 
 .fs-search-form__input {
   font-size: 0.8em;
@@ -257,6 +263,14 @@
  */
 .fs-search-form__autocomplete-container {
   display: flex; }
+  @media (min-width: 600px) {
+    .fs-search-form__autocomplete-container {
+      width: 75%; } }
+  @media (min-width: 1100px) {
+    .fs-search-form__autocomplete-container {
+      width: 50%; } }
+  .fs-search-form__autocomplete-container .fs-search-form__input-wrapper {
+    width: 100%; }
 
 /** These classes are outside of Federated Search app namespace. **/
 .react-autosuggest__container {
@@ -541,8 +555,8 @@
   @media (min-width: 900px) {
     .fs-container {
       display: grid;
-      grid-column-gap: 5%;
-      grid-template-columns: 33% 66%;
+      grid-column-gap: 0;
+      grid-template-columns: 25% 75%;
       width: 90%;
       padding: 0; } }
   @media (min-width: 900px) {
@@ -571,6 +585,19 @@
  *
  * @copyright Copyright (c) 2017-2020 Palantir.net
  */
+@media (min-width: 900px) {
+  .fs-main {
+    padding-left: 7.5%; } }
+
+@media (min-width: 900px) {
+  .fs-main.fs-main__has-custom-columns {
+    padding-left: 2em; } }
+
+@media (min-width: 900px) {
+  .fs-main__desktop-reverse {
+    padding-left: 0;
+    padding-right: 2em; } }
+
 /**
  * fs-search-results.scss
  * Define search results styles.
@@ -643,6 +670,60 @@
  */
 .fs-search-scope {
   margin: 1.46667em 0; }
+
+.fs-search-scope__filter {
+  width: 48.57143%;
+  clear: right;
+  float: left;
+  margin-left: 0;
+  margin-right: 2.85714%; }
+  @media (min-width: 600px) {
+    .fs-search-scope__filter {
+      width: 31.42857%;
+      clear: right;
+      float: left;
+      margin-left: 0;
+      margin-right: 2.85714%; } }
+  .fs-search-scope__filter:nth-of-type(3n+1) {
+    width: 48.57143%;
+    clear: right;
+    float: left;
+    margin-left: 0;
+    margin-right: 2.85714%;
+    clear: both; }
+    @media (min-width: 600px) {
+      .fs-search-scope__filter:nth-of-type(3n+1) {
+        width: 31.42857%;
+        float: left;
+        margin-right: -100%;
+        margin-left: 0;
+        clear: both; } }
+  .fs-search-scope__filter:nth-of-type(3n+2) {
+    width: 48.57143%;
+    clear: right;
+    float: right;
+    margin-right: 0; }
+    @media (min-width: 600px) {
+      .fs-search-scope__filter:nth-of-type(3n+2) {
+        width: 31.42857%;
+        float: left;
+        margin-right: -100%;
+        margin-left: 34.28571%;
+        clear: none; } }
+  .fs-search-scope__filter:nth-of-type(3n+3) {
+    width: 48.57143%;
+    clear: right;
+    float: left;
+    margin-left: 0;
+    margin-right: 2.85714%;
+    clear: both; }
+    @media (min-width: 600px) {
+      .fs-search-scope__filter:nth-of-type(3n+3) {
+        width: 31.42857%;
+        float: right;
+        margin-left: 0;
+        margin-right: 0;
+        clear: none; } }
 
 .fs-search-scope__select {
   font-size: 0.8em;

--- a/src/styles.css
+++ b/src/styles.css
@@ -531,6 +531,7 @@
  * @copyright Copyright (c) 2017-2020 Palantir.net
  */
 .fs-container {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -532,12 +532,21 @@
  */
 .fs-container {
   display: flex;
-  flex-direction: column; }
+  flex-direction: column;
+  width: 100%;
+  min-width: 260px;
+  padding: 0 1.46667em;
+  margin: 0 auto; }
   @media (min-width: 900px) {
     .fs-container {
       display: grid;
-      grid-column-gap: 1em;
-      grid-template-columns: 33% 66%; } }
+      grid-column-gap: 5%;
+      grid-template-columns: 33% 66%;
+      width: 90%;
+      padding: 0; } }
+  @media (min-width: 900px) {
+    .fs-container {
+      max-width: 1400px; } }
 
 /**
  * aside.scss

--- a/src/styles.css
+++ b/src/styles.css
@@ -525,22 +525,25 @@
     content: "–"; }
 
 /**
+ * container.scss
+ * Define container styles.
+ *
+ * @copyright Copyright (c) 2017-2020 Palantir.net
+ */
+@media (min-width: 900px) {
+  .fs-container {
+    display: grid;
+    grid-column-gap: 1em;
+    grid-template-columns: 33% 66%; } }
+
+/**
  * aside.scss
  * Define aside styles.
  *
  * @copyright Copyright (c) 2017-2019 Palantir.net
  */
 .fs-aside {
-  width: 22.85714%;
-  float: left;
-  margin-right: -100%;
-  margin-left: 0;
-  clear: both;
-  margin-bottom: 1.46667em;
   background-color: #f6f6f6; }
-  @media (min-width: 900px) {
-    .fs-aside {
-      padding-top: 1.46667em; } }
 
 /**
  * aside.scss
@@ -548,17 +551,6 @@
  *
  * @copyright Copyright (c) 2017-2020 Palantir.net
  */
-.fs-main {
-  width: 74.28571%;
-  float: right;
-  margin-left: 0;
-  margin-right: 0;
-  clear: none;
-  margin-bottom: 1.46667em; }
-  @media (min-width: 900px) {
-    .fs-main {
-      padding-top: 1.46667em; } }
-
 /**
  * fs-search-results.scss
  * Define search results styles.

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,6 +21,7 @@
 @import "components/text-search/fs-search-form";
 @import "components/text-search/fs-autocomplete";
 @import "components/fs-search-filters";
+@import "components/fs-container";
 @import "components/fs-aside";
 @import "components/fs-main";
 @import "components/results/fs-search-results";


### PR DESCRIPTION
Proof of concept for [FS-9](https://palantir.atlassian.net/browse/FS-9)

Add this to env.local.js

```
    // OPTIONAL: Specify the column widths.
    gridTemplateColumns: "50% 50%",
    // OPTIONAL: Add custom classes.
    containerClass: "custom-container",
    asideClass: "custom-aside",
    mainClass: "custom-main",
    // OPTIONAl: Reverse desktop column order.
    reverseDesktopColumns: true,
    // OPTIONAL: Reverse mobile stack order.
    reverseMobileOrder: false,
    // Breakpoint for Desktop. Layout will change when wider then the value specifed.
    breakpointDesktop: 1000,
  },
```

Note that 
- desktop columns are now 50/50 
- Filters are on the right at desktop but still on top for mobile
- filter drawer opens at 1000px wide (other styles would still need breakpoint adjusted in override CSS)
- Custom classes appear as expected
