### PR TITLE
Add onResize for show/hide on facets.

### DIFF
--- a/src/components/search-field-container.js
+++ b/src/components/search-field-container.js
@@ -9,7 +9,7 @@ class FederatedSearchFieldContainer extends React.Component {
     super(props);
 
     // This will return the width of the viewport.
-    const intFrameWidth = window.innerWidth;
+    let intFrameWidth = window.innerWidth;
 
     this.state = {
       // Filters are visible for large / hidden for small screens by default.
@@ -17,6 +17,18 @@ class FederatedSearchFieldContainer extends React.Component {
     };
 
     this.handleClick = this.handleClick.bind(this);
+
+    window.addEventListener('resize', () => {
+      // Desktop height.
+      let height = 'auto';
+      // In mobile view, when resized, lets close things.
+      if (window.innerWidth < 900) {
+        height = 0;
+      }
+      this.setState({
+        expanded: height,
+      });
+    });
   }
 
   handleClick() {


### PR DESCRIPTION
To test

Run `yarn start` and view `localhost`
Verify that when resizing to mobile view, the facets are `hidden` until `+` is clicked.
Verify that when resizing to desktop, the facets after 900 are `shown`