### PR TITLE
fix "FALSE is not defined" errors

### DIFF
--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -61,7 +61,7 @@ module.exports = {
   // ],
   // OPTIONAL: Provides config for adding autocomplete functionality to text search, defaults to false
   // autocomplete : {
-  //   proxyIsDisabled: FALSE, // REQUIRED: whether or not your url is set to the query solr directly (defaults to false),
+  //   proxyIsDisabled: false, // REQUIRED: whether or not your url is set to the query solr directly (defaults to false),
   //   url: <your-endpoint-for-autocomplete-results>, // REQUIRED: using the proxy is recommended but can also be set to a Drupal search view REST export, or if necessary, a Solr backend
   //   appendWildcard: false, // OPTIONAL: defaults to false, whether or not to append wildcard to query term
   //   suggestionRows: 5, // OPTIONAL: defaults to 5

--- a/src/.env.local.js.example
+++ b/src/.env.local.js.example
@@ -19,9 +19,9 @@
 
 module.exports = {
   // REQUIRED (for Drupal 7): Flag set to indicate a Drupal 7 site (proxy requests use "search" vs "q")
-  isD7: FALSE, // Defaults to FALSE
+  isD7: false, // Defaults to FALSE
   // REQUIRED: Whether or not the url provided is the solr proxy (default: FALSE, uses the proxy)
-  proxyIsDisabled: FALSE,
+  proxyIsDisabled: false,
   // REQUIRED: The url to where the query request should be made.
   //    If using the Federated Search Demo site with the proxy, use:
   //        http://d8.fs-demo.local/search-api-federated-solr/search


### PR DESCRIPTION
Was getting "FALSE is not defined" in the console when using this example config. This updates the values to the lower-case `false`.